### PR TITLE
Fix for variable access waring in Puppet 3.2

### DIFF
--- a/templates/redis.init.erb
+++ b/templates/redis.init.erb
@@ -12,14 +12,14 @@ CONF="/etc/redis/${REDIS_PORT}.conf"
 ###############
 
 # chkconfig: 2345 95 20
-# description: redis_<%= redis_port %> is the redis daemon.
+# description: redis_<%= @redis_port %> is the redis daemon.
 ### BEGIN INIT INFO
-# Provides: redis_<%= redis_port %>
-# Required-Start: 
-# Required-Stop: 
-# Should-Start: 
-# Should-Stop: 
-# Short-Description: start and stop redis_<%= redis_port %>
+# Provides: redis_<%= @redis_port %>
+# Required-Start:
+# Required-Stop:
+# Should-Start:
+# Should-Stop:
+# Short-Description: start and stop redis_<%= @redis_port %>
 # Description: Redis daemon
 ### END INIT INFO
 
@@ -80,7 +80,7 @@ status()
 
 case "$1" in
     start)
-  start 
+  start
   ;;
     stop)
   stop


### PR DESCRIPTION
Since Puppet version 3.2, allot of warnings are shown while using the redis module.

`Warning: Variable access via 'redis_port' is deprecated. Use '@redis_port' instead`

This fix this, Puppetlabs recommends to use a @-[prefix](http://docs.puppetlabs.com/guides/templating.html#referencing-variables).

Also removed some not needed trailing white spaces.
