### PR TITLE
Allow configuration parameters to be applied to default server.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,47 @@
 #   Location to install redis binaries.
 #   Default: /opt/redis
 #
+# [*redis_port*]
+#   Accept redis connections on this port.
+#   Default: 6379
+#
+# [*redis_bind_address*]
+#   Address to bind to.
+#   Default: false, which binds to all interfaces
+#
+# [*redis_max_clients*]
+#   Set the redis config value maxclients. If no value provided, it is
+#   not included in the configuration for 2.6 and set to 0 (unlimited)
+#   for 2.4.
+#   Default: 0 (2.4)
+#   Default: nil (2.6)
+#
+# [*redis_timeout*]
+#   Set the redis config value timeout (seconds).
+#   Default: 300
+#
+# [*redis_loglevel*]
+#   Set the redis config value loglevel. Valid values are debug,
+#   verbose, notice, and warning.
+#   Default: notice
+#
+# [*redis_databases*]
+#   Set the redis config value databases.
+#   Default: 16
+#
+# [*redis_slowlog_log_slower_than*]
+#   Set the redis config value slowlog-log-slower-than (microseconds).
+#   Default: 10000
+#
+# [*redis_showlog_max_len*]
+#   Set the redis config value slowlog-max-len.
+#   Default: 1024
+#
+# [*redis_password*]
+#   Password used by AUTH command. Will be setted is its not nil.
+#   Default: nil
+
+#
 # === Examples
 #
 # include redis
@@ -37,7 +78,17 @@
 class redis (
   $version = $redis::params::version,
   $redis_src_dir = $redis::params::redis_src_dir,
-  $redis_bin_dir = $redis::params::redis_bin_dir
+  $redis_bin_dir = $redis::params::redis_bin_dir,
+  $redis_port = $redis::params::redis_port,
+  $redis_bind_address = $redis::params::redis_bind_address,
+  $redis_max_memory = $redis::params::redis_max_memory,
+  $redis_max_clients = $redis::params::redis_max_clients,
+  $redis_timeout = $redis::params::redis_timeout,
+  $redis_loglevel = $redis::params::redis_loglevel,
+  $redis_databases = $redis::params::redis_databases,
+  $redis_slowlog_log_slower_than = $redis::params::redis_slowlog_log_slower_than,
+  $redis_slowlog_max_len = $redis::params::redis_slowlog_max_len,
+  $redis_password = $redis::params::redis_password
 ) inherits redis::params {
 
   include wget
@@ -47,7 +98,18 @@ class redis (
   $redis_pkg = "${redis_src_dir}/${redis_pkg_name}"
 
   # Install default instance
-  redis::instance { 'redis-default': }
+  redis::instance { 'redis-default':
+    redis_port                    => $redis_port,
+    redis_bind_address            => $redis_bind_address,
+    redis_max_memory              => $redis_max_memory,
+    redis_max_clients             => $redis_max_clients,
+    redis_timeout                 => $redis_timeout,
+    redis_loglevel                => $redis_loglevel,
+    redis_databases               => $redis_databases,
+    redis_slowlog_log_slower_than => $redis_slowlog_log_slower_than,
+    redis_slowlog_max_len         => $redis_slowlog_max_len,
+    redis_password                => $redis_password,
+  }
 
   File {
     owner => root,


### PR DESCRIPTION
This pull request add the redis::instance parameters to the default class so the default instance can be configured.
