### PR TITLE
Modified the default redis version and get-redis-pkg link

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@
 #
 # [*version*]
 #   Version to install.
-#   Default: 2.4.13
+#   Default: 2.6.16
 #
 # [*redis_src_dir*]
 #   Location to unpack source code before building and installing it.
@@ -75,7 +75,7 @@ class redis (
     }
   }
   exec { 'get-redis-pkg':
-    command => "/usr/bin/wget --output-document ${redis_pkg} http://redis.googlecode.com/files/${redis_pkg_name}",
+    command => "/usr/bin/wget --output-document ${redis_pkg} http://download.redis.io/releases/${redis_pkg_name}",
     unless  => "/usr/bin/test -f ${redis_pkg}",
     require => File[$redis_src_dir],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,7 +16,7 @@ class redis::params {
 
   $redis_port = '6379'
   $redis_bind_address = false
-  $version = '2.4.13'
+  $version = '2.6.16'
   $redis_src_dir = '/opt/redis-src'
   $redis_bin_dir = '/opt/redis'
   $redis_max_memory = '4gb'


### PR DESCRIPTION
Hello, I've modified the default Redis version with the latest stable one and the download link for get-redis-pkg. I've tested on CentOS release 6.4 (Final) and it works as expected. 

All the best, 
Andrei Halici
