### PR TITLE
Fixing deprecation with template variable access

### DIFF
--- a/templates/redis.init.erb
+++ b/templates/redis.init.erb
@@ -12,14 +12,14 @@ CONF="/etc/redis/${REDIS_PORT}.conf"
 ###############
 
 # chkconfig: 2345 95 20
-# description: redis_<%= redis_port %> is the redis daemon.
+# description: redis_<%= @redis_port %> is the redis daemon.
 ### BEGIN INIT INFO
-# Provides: redis_<%= redis_port %>
-# Required-Start: 
-# Required-Stop: 
-# Should-Start: 
-# Should-Stop: 
-# Short-Description: start and stop redis_<%= redis_port %>
+# Provides: redis_<%= @redis_port %>
+# Required-Start:
+# Required-Stop:
+# Should-Start:
+# Should-Stop:
+# Short-Description: start and stop redis_<%= @redis_port %>
 # Description: Redis daemon
 ### END INIT INFO
 
@@ -80,7 +80,7 @@ status()
 
 case "$1" in
     start)
-  start 
+  start
   ;;
     stop)
   stop


### PR DESCRIPTION
Quick update to fix the variable access.

```
Warning: Variable access via 'redis_port' is deprecated. Use '@redis_port' instead.
```

Some whitespace trimming has also been committed.
