### PR TITLE
Update redis.init.erb

### DIFF
--- a/templates/redis.init.erb
+++ b/templates/redis.init.erb
@@ -12,14 +12,14 @@ CONF="/etc/redis/${REDIS_PORT}.conf"
 ###############
 
 # chkconfig: 2345 95 20
-# description: redis_<%= redis_port %> is the redis daemon.
+# description: redis_<%= @redis_port %> is the redis daemon.
 ### BEGIN INIT INFO
-# Provides: redis_<%= redis_port %>
+# Provides: redis_<%= @redis_port %>
 # Required-Start: 
 # Required-Stop: 
 # Should-Start: 
 # Should-Stop: 
-# Short-Description: start and stop redis_<%= redis_port %>
+# Short-Description: start and stop redis_<%= @redis_port %>
 # Description: Redis daemon
 ### END INIT INFO
 


### PR DESCRIPTION
When I tried to apply manifest via puppet 3.4.3 I got next message:

Warning: Variable access via 'redis_port' is deprecated. Use '@redis_port' instead. template[/etc/puppet/modules/redis/templates/redis.init.erb]:15
   (at /etc/puppet/modules/redis/templates/redis.init.erb:15:in `block in result')
Warning: Variable access via 'redis_port' is deprecated. Use '@redis_port' instead. template[/etc/puppet/modules/redis/templates/redis.init.erb]:17
   (at /etc/puppet/modules/redis/templates/redis.init.erb:17:in`block in result')
Warning: Variable access via 'redis_port' is deprecated. Use '@redis_port' instead. template[/etc/puppet/modules/redis/templates/redis.init.erb]:22
   (at /etc/puppet/modules/redis/templates/redis.init.erb:22:in `block in result')

Please, take into account this changes. Thank you!
