### PR TITLE
Support latest puppet versions

### DIFF
--- a/.gemfile
+++ b/.gemfile
@@ -5,3 +5,4 @@ puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>=
 gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 0.2.1'
+gem 'puppet-syntax'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ before_script:
   - "[ '2.6.9' = $PUPPET_VERSION ] && git clone git://github.com/puppetlabs/puppetlabs-create_resources.git spec/fixtures/modules/create_resources || true"
 after_script:
 script:
-  - "rake lint"
-  - "rake spec"
+  - "rake test"
 env:
   - PUPPET_VERSION=2.7.13
   - PUPPET_VERSION=2.6.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
   - PUPPET_VERSION=2.7.13
   - PUPPET_VERSION=2.6.9
   - PUPPET_VERSION=3.1.1
+  - PUPPET_VERSION=3.4.3
+
 notifications:
   email: thomas.vandoren@gmail.com
 gemfile: .gemfile

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,19 @@
 require 'puppetlabs_spec_helper/rake_tasks'
-
-# This ensures that PuppetLint is available for configuration.
 require 'puppet-lint/tasks/puppet-lint'
+require 'puppet-syntax/tasks/puppet-syntax'
 
 PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('disable_80chars')
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+
+exclude_paths = [
+  "spec/**/*",
+]
+PuppetSyntax.exclude_paths = exclude_paths
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+]

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -11,8 +11,8 @@ describe 'redis', :type => 'class' do
     end # let
 
     it do
-      should include_class('gcc')
-      should include_class('wget')
+      should contain_class('gcc')
+      should contain_class('wget')
 
       should contain_file('/opt/redis-src').with(:ensure => 'directory')
       should contain_file('/etc/redis').with(:ensure => 'directory')
@@ -72,8 +72,8 @@ describe 'redis', :type => 'class' do
     end # let
 
     it do
-      should include_class('gcc')
-      should include_class('wget')
+      should contain_class('gcc')
+      should contain_class('wget')
 
       should contain_file('/fake/path/to/redis-src').with(:ensure => 'directory')
       should contain_file('/etc/redis').with(:ensure => 'directory')

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'redis::instance', :type => 'define' do
   let(:title) { 'redis-instance' }
 
-  context "On Debian systems with no password parameter" do
+  context "On Debian systems" do
 
     let :facts do
       {
@@ -11,65 +11,63 @@ describe 'redis::instance', :type => 'define' do
       }
     end # let
 
-    let :params do
-      {
-        :redis_password => false
-      }
-    end # let
+    context "with no password parameter" do
+      let :params do
+        {
+          :redis_password => false
+        }
+      end # let
 
-    it do
-      should_not contain_file('redis_port_6379.conf').with_content(/^requirepass/)
-    end # it
-  end # context
+      it do
+        should_not contain_file('redis_port_6379.conf').with_content(/^requirepass/)
+      end # it
+    end # context
 
-  context "On Debian systems with password parameter" do
+    context "With password parameter" do
 
-    let :facts do
-      {
-        :osfamily  => 'Debian'
-      }
-    end # let
+      let :params do
+        {
+          :redis_port     => '6900',
+          :redis_password => 'ThisIsAReallyBigSecret'
+        }
+      end # let
 
-    let :params do
-      {
-        :redis_port     => '6900',
-        :redis_password => 'ThisIsAReallyBigSecret'
-      }
-    end # let
+      it do
+        should contain_file('redis_port_6900.conf').with_content(/^requirepass ThisIsAReallyBigSecret/)
+        should contain_file('redis-init-6900').with_content(/^CLIEXEC="[\w\/]+redis-cli -h \$REDIS_BIND_ADDRESS -p \$REDIS_PORT -a ThisIsAReallyBigSecret/)
+      end # it
+    end # context
 
-    it do
-      should contain_file('redis_port_6900.conf').with_content(/^requirepass ThisIsAReallyBigSecret/)
-      should contain_file('redis-init-6900').with_content(/^CLIEXEC="[\w\/]+redis-cli -h \$REDIS_BIND_ADDRESS -p \$REDIS_PORT -a ThisIsAReallyBigSecret/)
-    end # it
-  end # context
+    context "With a non-default port parameter" do
+      
+      let :params do
+        {
+          :redis_port => '6900'
+        }
+      end # let
 
-  context "With a non-default port parameter" do
-    let :params do
-      {
-        :redis_port => '6900'
-      }
-    end # let
+      it do
+        should contain_file('redis_port_6900.conf').with_content(/^port 6900$/)
+        should contain_file('redis_port_6900.conf').with_content(/^pidfile \/var\/run\/redis_6900\.pid$/)
+        should contain_file('redis_port_6900.conf').with_content(/^logfile \/var\/log\/redis_6900\.log$/)
+        should contain_file('redis_port_6900.conf').with_content(/^dir \/var\/lib\/redis\/6900$/)
+        should contain_file('redis-init-6900').with_content(/^REDIS_PORT="6900"$/)
+      end # it
+    end # context
 
-    it do
-      should contain_file('redis_port_6900.conf').with_content(/^port 6900$/)
-      should contain_file('redis_port_6900.conf').with_content(/^pidfile \/var\/run\/redis_6900\.pid$/)
-      should contain_file('redis_port_6900.conf').with_content(/^logfile \/var\/log\/redis_6900\.log$/)
-      should contain_file('redis_port_6900.conf').with_content(/^dir \/var\/lib\/redis\/6900$/)
-      should contain_file('redis-init-6900').with_content(/^REDIS_PORT="6900"$/)
-    end # it
-  end # context
+    context "With a non default bind address" do
 
-  context "With a non default bind address" do
-    let :params do
-      {
-        :redis_port => '6900',
-        :redis_bind_address => '10.1.2.3'
-      }
-    end # let
+      let :params do
+        {
+          :redis_port => '6900',
+          :redis_bind_address => '10.1.2.3'
+        }
+      end # let
 
-    it do
-      should contain_file('redis_port_6900.conf').with_content(/^bind 10\.1\.2\.3$/)
-      should contain_file('redis-init-6900').with_content(/^REDIS_BIND_ADDRESS="10.1.2.3"$/)
-    end # it
+      it do
+        should contain_file('redis_port_6900.conf').with_content(/^bind 10\.1\.2\.3$/)
+        should contain_file('redis-init-6900').with_content(/^REDIS_BIND_ADDRESS="10.1.2.3"$/)
+      end # it
+    end # context
   end # context
 end # describe

--- a/templates/redis.init.erb
+++ b/templates/redis.init.erb
@@ -12,14 +12,14 @@ CONF="/etc/redis/${REDIS_PORT}.conf"
 ###############
 
 # chkconfig: 2345 95 20
-# description: redis_<%= redis_port %> is the redis daemon.
+# description: redis_<%= @redis_port %> is the redis daemon.
 ### BEGIN INIT INFO
-# Provides: redis_<%= redis_port %>
+# Provides: redis_<%= @redis_port %>
 # Required-Start: 
 # Required-Stop: 
 # Should-Start: 
 # Should-Stop: 
-# Short-Description: start and stop redis_<%= redis_port %>
+# Short-Description: start and stop redis_<%= @redis_port %>
 # Description: Redis daemon
 ### END INIT INFO
 


### PR DESCRIPTION
A bunch of changes to improve tests and fix templates for 3.0
- Refactor `instace_spec` to always provide `osfamily`
- Add newer versions of puppet to the travis build matrix
- Rename `include_class` to `contain_class`
- Add `puppet-syntax`
- Fix template warnings in puppet 3.0
