### PR TITLE
added Default-Start and Default-Stop to the init.d script template

### DIFF
--- a/templates/redis.init.erb
+++ b/templates/redis.init.erb
@@ -19,6 +19,8 @@ CONF="/etc/redis/${REDIS_PORT}.conf"
 # Required-Stop: 
 # Should-Start: 
 # Should-Stop: 
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
 # Short-Description: start and stop redis_<%= @redis_port %>
 # Description: Redis daemon
 ### END INIT INFO


### PR DESCRIPTION
On Debian 7.5, the lack of specified default run levels was preventing provisioned redis instances from starting on boot.
