### PR TITLE
added the option to install only the cli

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,7 +98,8 @@ class redis (
   $redis_slowlog_log_slower_than = $redis::params::redis_slowlog_log_slower_than,
   $redis_slowlog_max_len = $redis::params::redis_slowlog_max_len,
   $redis_password = $redis::params::redis_password,
-  $redis_saves = $redis::params::redis_saves
+  $redis_saves = $redis::params::redis_saves,
+  $redis_server = $redis::params::redis_server
 ) inherits redis::params {
 
   include wget
@@ -120,6 +121,7 @@ class redis (
     redis_slowlog_max_len         => $redis_slowlog_max_len,
     redis_password                => $redis_password,
     redis_saves                   => $redis_saves,
+    redis_server                  => $redis_server,
   }
 
   File {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,5 +30,6 @@ class redis::params {
   $redis_saves = ['save 900 1', 'save 300 10', 'save 60 10000']
   $redis_user = 'root'
   $redis_group = 'root'
+  $redis_server = true
 
 }


### PR DESCRIPTION
Hey, I needed to install only the client (not the server) so, I modified the module and added an option called "redis_server"

Tested on centos and worked well
