### PR TITLE
Configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ class { 'redis':
 }
 ```
 
-Installs version 2.4.17, listens on default port 6379 with default settings.
+Installs version 2.6.17, listens on default port 6379 with default settings.
 Sets up 2nd instance on port 6900, binds to address 10.1.2.3 (instead of all 
 available interfaces), sets max memory to 1 gigabyte, and sets a password from 
 hiera.
 
 ```puppet
 class { 'redis':
-  version            => '2.4.17',
+  version            => '2.6.17',
 }
 redis::instance { 'redis-6900':
   redis_port         => '6900',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,6 +93,30 @@
 #   Append Only File rewrite incremental fsync.
 #   Default: true
 #
+# [*redis_cluster_enabled*]
+#   Cluster enabled.
+#   Default: false (>= 3.0.0)
+#
+# [*redis_cluster_config_file*]
+#   Cluster config file for nodes.
+#   Default: nodes-6379.conf (>= 3.0.0)
+#
+# [*redis_cluster_node_timeout*]
+#   Cluster node timeout.
+#   Default: 15000 (>= 3.0.0)
+#
+# [*redis_cluster_slave_validity_factor*]
+#   Cluster slave validity factor for failover.
+#   Default: 10 (>= 3.0.0)
+#
+# [*redis_cluster_migration_barrier*]
+#   Cluster migration barrier for slaves.
+#   Default: 1 (>= 3.0.0)
+#
+# [*redis_cluster_require_full_coverage*]
+#   Cluster require full coverage of hash slots.
+#   Default: true (>= 3.0.0)
+#
 # === Examples
 #
 # include redis
@@ -135,7 +159,13 @@ class redis (
   $redis_auto_aof_rewrite_percentage = $redis::params::redis_auto_aof_rewrite_percentage,
   $redis_auto_aof_rewrite_min_size = $redis::params::redis_auto_aof_rewrite_min_size,
   $redis_aof_load_truncated = $redis::params::redis_aof_load_truncated,
-  $redis_aof_rewrite_incremental_fsync = $redis::params::redis_aof_rewrite_incremental_fsync
+  $redis_aof_rewrite_incremental_fsync = $redis::params::redis_aof_rewrite_incremental_fsync,
+  $redis_cluster_enabled = $redis::params::redis_cluster_enabled,
+  $redis_cluster_config_file = $redis::params::redis_cluster_config_file,
+  $redis_cluster_node_timeout = $redis::params::redis_cluster_node_timeout,
+  $redis_cluster_slave_validity_factor = $redis::params::redis_cluster_slave_validity_factor,
+  $redis_cluster_migration_barrier = $redis::params::redis_cluster_migration_barrier,
+  $redis_cluster_require_full_coverage = $redis::params::redis_cluster_require_full_coverage
 ) inherits redis::params {
 
   include wget
@@ -165,6 +195,12 @@ class redis (
     redis_auto_aof_rewrite_min_size     => $redis_auto_aof_rewrite_min_size,
     redis_aof_load_truncated            => $redis_aof_load_truncated,
     redis_aof_rewrite_incremental_fsync => $redis_aof_rewrite_incremental_fsync,
+    redis_cluster_enabled               => $redis_cluster_enabled,
+    redis_cluster_config_file           => $redis_cluster_config_file,
+    redis_cluster_node_timeout          => $redis_cluster_node_timeout,
+    redis_cluster_slave_validity_factor => $redis_cluster_slave_validity_factor,
+    redis_cluster_migration_barrier     => $redis_cluster_migration_barrier,
+    redis_cluster_require_full_coverage => $redis_cluster_require_full_coverage,
   }
 
   File {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -117,6 +117,10 @@
 #   Cluster require full coverage of hash slots.
 #   Default: true (>= 3.0.0)
 #
+# [*redis_max_memory_policy*]
+#   Set the redis config value maxmemory-policy.
+#   Default: noeviction
+#
 # === Examples
 #
 # include redis
@@ -165,7 +169,8 @@ class redis (
   $redis_cluster_node_timeout = $redis::params::redis_cluster_node_timeout,
   $redis_cluster_slave_validity_factor = $redis::params::redis_cluster_slave_validity_factor,
   $redis_cluster_migration_barrier = $redis::params::redis_cluster_migration_barrier,
-  $redis_cluster_require_full_coverage = $redis::params::redis_cluster_require_full_coverage
+  $redis_cluster_require_full_coverage = $redis::params::redis_cluster_require_full_coverage,
+  $redis_max_memory_policy = $redis::params::redis_max_memory_policy
 ) inherits redis::params {
 
   include wget
@@ -201,6 +206,7 @@ class redis (
     redis_cluster_slave_validity_factor => $redis_cluster_slave_validity_factor,
     redis_cluster_migration_barrier     => $redis_cluster_migration_barrier,
     redis_cluster_require_full_coverage => $redis_cluster_require_full_coverage,
+    redis_max_memory_policy             => $redis_max_memory_policy,
   }
 
   File {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,6 +61,38 @@
 #   Redis snapshotting parameters. Set to false for no snapshots.
 #   Default: ['save 900 1', 'save 300 10', 'save 60 10000']
 #
+# [*redis_appendonly*]
+#   Append Only File persistence mode.
+#   Default: false
+#
+# [*redis_appendfilename*]
+#   Append Only File name.
+#   Default: appendonly.aof
+#
+# [*redis_appendfsync*]
+#   Append Only File fsync mode.
+#   Default: everysec
+#
+# [*redis_no_appendfsync_on_rewrite*]
+#   Append Only File prevent fsync during rewrite.
+#   Default: false
+#
+# [*redis_auto_aof_rewrite_percentage*]
+#   Append Only File auto-rewrite percentage.
+#   Default: 100
+#
+# [*redis_auto_aof_rewrite_min_size*]
+#   Append Only File auto-rewrite size.
+#   Default: 64mb
+#
+# [*redis_aof_load_truncated*]
+#   Append Only File load truncated.
+#   Default: true (>= 2.8.15)
+#
+# [*redis_aof_rewrite_incremental_fsync*]
+#   Append Only File rewrite incremental fsync.
+#   Default: true
+#
 # === Examples
 #
 # include redis
@@ -95,7 +127,15 @@ class redis (
   $redis_slowlog_log_slower_than = $redis::params::redis_slowlog_log_slower_than,
   $redis_slowlog_max_len = $redis::params::redis_slowlog_max_len,
   $redis_password = $redis::params::redis_password,
-  $redis_saves = $redis::params::redis_saves
+  $redis_saves = $redis::params::redis_saves,
+  $redis_appendonly = $redis::params::redis_appendonly,
+  $redis_appendfilename = $redis::params::redis_appendfilename,
+  $redis_appendfsync = $redis::params::redis_appendfsync,
+  $redis_no_appendfsync_on_rewrite = $redis::params::redis_no_appendfsync_on_rewrite,
+  $redis_auto_aof_rewrite_percentage = $redis::params::redis_auto_aof_rewrite_percentage,
+  $redis_auto_aof_rewrite_min_size = $redis::params::redis_auto_aof_rewrite_min_size,
+  $redis_aof_load_truncated = $redis::params::redis_aof_load_truncated,
+  $redis_aof_rewrite_incremental_fsync = $redis::params::redis_aof_rewrite_incremental_fsync
 ) inherits redis::params {
 
   include wget
@@ -106,17 +146,25 @@ class redis (
 
   # Install default instance
   redis::instance { 'redis-default':
-    redis_port                    => $redis_port,
-    redis_bind_address            => $redis_bind_address,
-    redis_max_memory              => $redis_max_memory,
-    redis_max_clients             => $redis_max_clients,
-    redis_timeout                 => $redis_timeout,
-    redis_loglevel                => $redis_loglevel,
-    redis_databases               => $redis_databases,
-    redis_slowlog_log_slower_than => $redis_slowlog_log_slower_than,
-    redis_slowlog_max_len         => $redis_slowlog_max_len,
-    redis_password                => $redis_password,
-    redis_saves                   => $redis_saves,
+    redis_port                          => $redis_port,
+    redis_bind_address                  => $redis_bind_address,
+    redis_max_memory                    => $redis_max_memory,
+    redis_max_clients                   => $redis_max_clients,
+    redis_timeout                       => $redis_timeout,
+    redis_loglevel                      => $redis_loglevel,
+    redis_databases                     => $redis_databases,
+    redis_slowlog_log_slower_than       => $redis_slowlog_log_slower_than,
+    redis_slowlog_max_len               => $redis_slowlog_max_len,
+    redis_password                      => $redis_password,
+    redis_saves                         => $redis_saves,
+    redis_appendonly                    => $redis_appendonly,
+    redis_appendfilename                => $redis_appendfilename,
+    redis_appendfsync                   => $redis_appendfsync,
+    redis_no_appendfsync_on_rewrite     => $redis_no_appendfsync_on_rewrite,
+    redis_auto_aof_rewrite_percentage   => $redis_auto_aof_rewrite_percentage,
+    redis_auto_aof_rewrite_min_size     => $redis_auto_aof_rewrite_min_size,
+    redis_aof_load_truncated            => $redis_aof_load_truncated,
+    redis_aof_rewrite_incremental_fsync => $redis_aof_rewrite_incremental_fsync,
   }
 
   File {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,11 +29,8 @@
 #   Default: 4gb
 #
 # [*redis_max_clients*]
-#   Set the redis config value maxclients. If no value provided, it is
-#   not included in the configuration for 2.6+ and set to 0 (unlimited)
-#   for 2.4.
-#   Default: 0 (2.4)
-#   Default: nil (2.6+)
+#   Set the redis config value maxclients.
+#   Default: nil
 #
 # [*redis_timeout*]
 #   Set the redis config value timeout (seconds).

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -105,6 +105,10 @@
 #   Cluster require full coverage of hash slots.
 #   Default: true (>= 3.0.0)
 #
+# [*redis_max_memory_policy*]
+#   Set the redis config value maxmemory-policy.
+#   Default: noeviction
+#
 # === Examples
 #
 # redis::instance { 'redis-6900':
@@ -145,7 +149,8 @@ define redis::instance (
   $redis_cluster_node_timeout = $redis::params::redis_cluster_node_timeout,
   $redis_cluster_slave_validity_factor = $redis::params::redis_cluster_slave_validity_factor,
   $redis_cluster_migration_barrier = $redis::params::redis_cluster_migration_barrier,
-  $redis_cluster_require_full_coverage = $redis::params::redis_cluster_require_full_coverage
+  $redis_cluster_require_full_coverage = $redis::params::redis_cluster_require_full_coverage,
+  $redis_max_memory_policy = $redis::params::redis_max_memory_policy
 ) {
 
   # Using Exec as a dependency here to avoid dependency cyclying when doing

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -81,6 +81,30 @@
 #   Append Only File rewrite incremental fsync.
 #   Default: yes
 #
+# [*redis_cluster_enabled*]
+#   Cluster enabled.
+#   Default: false (>= 3.0.0)
+#
+# [*redis_cluster_config_file*]
+#   Cluster config file for nodes.
+#   Default: nodes-6379.conf (>= 3.0.0)
+#
+# [*redis_cluster_node_timeout*]
+#   Cluster node timeout.
+#   Default: 15000 (>= 3.0.0)
+#
+# [*redis_cluster_slave_validity_factor*]
+#   Cluster slave validity factor for failover.
+#   Default: 10 (>= 3.0.0)
+#
+# [*redis_cluster_migration_barrier*]
+#   Cluster migration barrier for slaves.
+#   Default: 1 (>= 3.0.0)
+#
+# [*redis_cluster_require_full_coverage*]
+#   Cluster require full coverage of hash slots.
+#   Default: true (>= 3.0.0)
+#
 # === Examples
 #
 # redis::instance { 'redis-6900':
@@ -115,7 +139,13 @@ define redis::instance (
   $redis_auto_aof_rewrite_percentage = $redis::params::redis_auto_aof_rewrite_percentage,
   $redis_auto_aof_rewrite_min_size = $redis::params::redis_auto_aof_rewrite_min_size,
   $redis_aof_load_truncated = $redis::params::redis_aof_load_truncated,
-  $redis_aof_rewrite_incremental_fsync = $redis::params::redis_aof_rewrite_incremental_fsync
+  $redis_aof_rewrite_incremental_fsync = $redis::params::redis_aof_rewrite_incremental_fsync,
+  $redis_cluster_enabled = $redis::params::redis_cluster_enabled,
+  $redis_cluster_config_file = $redis::params::redis_cluster_config_file,
+  $redis_cluster_node_timeout = $redis::params::redis_cluster_node_timeout,
+  $redis_cluster_slave_validity_factor = $redis::params::redis_cluster_slave_validity_factor,
+  $redis_cluster_migration_barrier = $redis::params::redis_cluster_migration_barrier,
+  $redis_cluster_require_full_coverage = $redis::params::redis_cluster_require_full_coverage
 ) {
 
   # Using Exec as a dependency here to avoid dependency cyclying when doing

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -49,6 +49,38 @@
 #   Redis snapshotting parameters. Set to false for no snapshots.
 #   Default: ['save 900 1', 'save 300 10', 'save 60 10000']
 #
+# [*redis_appendonly*]
+#   Append Only File persistence mode.
+#   Default: no
+#
+# [*redis_appendfilename*]
+#   Append Only File name.
+#   Default: appendonly.aof
+#
+# [*redis_appendfsync*]
+#   Append Only File fsync mode.
+#   Default: everysec
+#
+# [*redis_no_appendfsync_on_rewrite*]
+#   Append Only File prevent fsync during rewrite.
+#   Default: no
+#
+# [*redis_auto_aof_rewrite_percentage*]
+#   Append Only File auto-rewrite percentage.
+#   Default: 100
+#
+# [*redis_auto_aof_rewrite_min_size*]
+#   Append Only File auto-rewrite size.
+#   Default: 64mb
+#
+# [*redis_aof_load_truncated*]
+#   Append Only File load truncated.
+#   Default: yes (>= 2.8.15)
+#
+# [*redis_aof_rewrite_incremental_fsync*]
+#   Append Only File rewrite incremental fsync.
+#   Default: yes
+#
 # === Examples
 #
 # redis::instance { 'redis-6900':
@@ -75,8 +107,16 @@ define redis::instance (
   $redis_slowlog_log_slower_than = $redis::params::redis_slowlog_log_slower_than,
   $redis_slowlog_max_len = $redis::params::redis_slowlog_max_len,
   $redis_password = $redis::params::redis_password,
-  $redis_saves = $redis::params::redis_saves
-  ) {
+  $redis_saves = $redis::params::redis_saves,
+  $redis_appendonly = $redis::params::redis_appendonly,
+  $redis_appendfilename = $redis::params::redis_appendfilename,
+  $redis_appendfsync = $redis::params::redis_appendfsync,
+  $redis_no_appendfsync_on_rewrite = $redis::params::redis_no_appendfsync_on_rewrite,
+  $redis_auto_aof_rewrite_percentage = $redis::params::redis_auto_aof_rewrite_percentage,
+  $redis_auto_aof_rewrite_min_size = $redis::params::redis_auto_aof_rewrite_min_size,
+  $redis_aof_load_truncated = $redis::params::redis_aof_load_truncated,
+  $redis_aof_rewrite_incremental_fsync = $redis::params::redis_aof_rewrite_incremental_fsync
+) {
 
   # Using Exec as a dependency here to avoid dependency cyclying when doing
   # Class['redis'] -> Redis::Instance[$name]

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -17,11 +17,8 @@
 #   Default: 4gb
 #
 # [*redis_max_clients*]
-#   Set the redis config value maxclients. If no value provided, it is
-#   not included in the configuration for 2.6+ and set to 0 (unlimited)
-#   for 2.4.
-#   Default: 0 (2.4)
-#   Default: nil (2.6+)
+#   Set the redis config value maxclients.
+#   Default: nil
 #
 # [*redis_timeout*]
 #   Set the redis config value timeout (seconds).
@@ -87,23 +84,6 @@ define redis::instance (
   include redis
 
   $version = $redis::version
-
-  case $version {
-    /^2\.4\.\d+$/: {
-      if ($redis_max_clients == false) {
-        $real_redis_max_clients = 0
-      }
-      else {
-        $real_redis_max_clients = $redis_max_clients
-      }
-    }
-    /^2\.[68]\.\d+$/: {
-      $real_redis_max_clients = $redis_max_clients
-    }
-    default: {
-      fail("Invalid redis version, ${version}. It must match 2.4.\\d+ or 2.[68].\\d+.")
-    }
-  }
 
   file { "redis-lib-port-${redis_port}":
     ensure => directory,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,5 +38,11 @@ class redis::params {
   $redis_auto_aof_rewrite_min_size = '64mb'
   $redis_aof_load_truncated = true
   $redis_aof_rewrite_incremental_fsync = true
+  $redis_cluster_enabled = false
+  $redis_cluster_config_file = 'nodes-6379.conf'
+  $redis_cluster_node_timeout = 15000
+  $redis_cluster_slave_validity_factor = 10
+  $redis_cluster_migration_barrier = 1
+  $redis_cluster_require_full_coverage = true
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,5 +44,6 @@ class redis::params {
   $redis_cluster_slave_validity_factor = 10
   $redis_cluster_migration_barrier = 1
   $redis_cluster_require_full_coverage = true
+  $redis_max_memory_policy = 'noeviction'
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,5 +30,13 @@ class redis::params {
   $redis_saves = ['save 900 1', 'save 300 10', 'save 60 10000']
   $redis_user = 'root'
   $redis_group = 'root'
+  $redis_appendonly = false
+  $redis_appendfilename = 'appendonly.aof'
+  $redis_appendfsync = 'everysec'
+  $redis_no_appendfsync_on_rewrite = false
+  $redis_auto_aof_rewrite_percentage = 100
+  $redis_auto_aof_rewrite_min_size = '64mb'
+  $redis_aof_load_truncated = true
+  $redis_aof_rewrite_incremental_fsync = true
 
 }

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -59,7 +59,7 @@ describe 'redis', :type => 'class' do
       should contain_file('redis_port_6379.conf').with_content(/hash-max-ziplist-value 64/)
 
       # The bind config should not be present by default.
-      should_not contain_file('redis_port_6379.conf').with_content(/bind \d+\.\d+\.\d+\.\d+/)
+      should_not contain_file('redis_port_6379.conf').with_content(/^bind \d+\.\d+\.\d+\.\d+/)
     end # it
   end # context
 

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -215,6 +215,48 @@ describe 'redis', :type => 'class' do
       should contain_file('redis_port_8000.conf').with_content(/^auto-aof-rewrite-percentage 42$/)
       should contain_file('redis_port_8000.conf').with_content(/^auto-aof-rewrite-min-size 32mb$/)
       should contain_file('redis_port_8000.conf').with_content(/^aof-rewrite-incremental-fsync no$/)
+      should_not contain_file('redis_port_8000.conf').with_content(/^cluster-enabled$/)
+    end # it
+  end # context
+
+  context "On a Debian system with version 3.0 param non-cluster" do
+    let :params do
+      {
+        :version    => '3.0.0-rc1',
+        :redis_port => '8001',
+      }
+    end # let
+
+    it do
+      should compile.with_all_deps
+      should contain_file('redis_port_8001.conf').with_ensure('present')
+      should contain_file('redis_port_8001.conf').with_content(/^cluster-enabled no$/)
+    end # it
+  end # context
+
+  context "On a Debian system with version 3.0 param cluster" do
+    let :params do
+      {
+        :version                             => '3.0.0-rc1',
+        :redis_port                          => '8001',
+        :redis_cluster_enabled               => true,
+        :redis_cluster_config_file           => 'node-config-8001.conf',
+        :redis_cluster_node_timeout          => 30000,
+        :redis_cluster_slave_validity_factor => 11,
+        :redis_cluster_migration_barrier     => 2,
+        :redis_cluster_require_full_coverage => false,
+      }
+    end # let
+
+    it do
+      should compile.with_all_deps
+      should contain_file('redis_port_8001.conf').with_ensure('present')
+      should contain_file('redis_port_8001.conf').with_content(/^cluster-enabled yes$/)
+      should contain_file('redis_port_8001.conf').with_content(/^cluster-config-file node-config-8001.conf$/)
+      should contain_file('redis_port_8001.conf').with_content(/^cluster-node-timeout 30000$/)
+      should contain_file('redis_port_8001.conf').with_content(/^cluster-slave-validity-factor 11$/)
+      should contain_file('redis_port_8001.conf').with_content(/^cluster-migration-barrier 2$/)
+      should contain_file('redis_port_8001.conf').with_content(/^cluster-require-full-coverage no$/)
     end # it
   end # context
 end # describe

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -172,17 +172,24 @@ describe 'redis', :type => 'class' do
   context "On a Debian system with instance parameters specified" do
     let :params do
       {
-        :redis_port                    => '8000',
-        :redis_bind_address            => '10.1.2.3',
-        :redis_max_memory              => '64gb',
-        :redis_max_clients             => '10000',
-        :redis_timeout                 => '15',
-        :redis_loglevel                => 'warning',
-        :redis_databases               => '64',
-        :redis_slowlog_log_slower_than => '5000',
-        :redis_slowlog_max_len         => '4096',
-        :redis_password                => 'sekrit',
-        :redis_saves                   => ['save 17 42', 'save 1 2']
+        :redis_port                          => '8000',
+        :redis_bind_address                  => '10.1.2.3',
+        :redis_max_memory                    => '64gb',
+        :redis_max_clients                   => '10000',
+        :redis_timeout                       => '15',
+        :redis_loglevel                      => 'warning',
+        :redis_databases                     => '64',
+        :redis_slowlog_log_slower_than       => '5000',
+        :redis_slowlog_max_len               => '4096',
+        :redis_password                      => 'sekrit',
+        :redis_saves                         => ['save 17 42', 'save 1 2'],
+        :redis_appendonly                    => true,
+        :redis_appendfilename                => 'aof.aof',
+        :redis_appendfsync                   => 'always',
+        :redis_no_appendfsync_on_rewrite     => true,
+        :redis_auto_aof_rewrite_percentage   => 42,
+        :redis_auto_aof_rewrite_min_size     => '32mb',
+        :redis_aof_rewrite_incremental_fsync => false
       }
     end # let
 
@@ -201,6 +208,13 @@ describe 'redis', :type => 'class' do
       should contain_file('redis_port_8000.conf').with_content(/^requirepass sekrit$/)
       should contain_file('redis_port_8000.conf').with_content(/^save 17 42$/)
       should contain_file('redis_port_8000.conf').with_content(/^save 1 2$/)
+      should contain_file('redis_port_8000.conf').with_content(/^appendonly yes$/)
+      should contain_file('redis_port_8000.conf').with_content(/^appendfilename "aof.aof"$/)
+      should contain_file('redis_port_8000.conf').with_content(/^appendfsync always$/)
+      should contain_file('redis_port_8000.conf').with_content(/^no-appendfsync-on-rewrite yes$/)
+      should contain_file('redis_port_8000.conf').with_content(/^auto-aof-rewrite-percentage 42$/)
+      should contain_file('redis_port_8000.conf').with_content(/^auto-aof-rewrite-min-size 32mb$/)
+      should contain_file('redis_port_8000.conf').with_content(/^aof-rewrite-incremental-fsync no$/)
     end # it
   end # context
 end # describe

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -189,7 +189,8 @@ describe 'redis', :type => 'class' do
         :redis_no_appendfsync_on_rewrite     => true,
         :redis_auto_aof_rewrite_percentage   => 42,
         :redis_auto_aof_rewrite_min_size     => '32mb',
-        :redis_aof_rewrite_incremental_fsync => false
+        :redis_aof_rewrite_incremental_fsync => false,
+        :redis_max_memory_policy             => 'volatile-lru'
       }
     end # let
 
@@ -215,6 +216,7 @@ describe 'redis', :type => 'class' do
       should contain_file('redis_port_8000.conf').with_content(/^auto-aof-rewrite-percentage 42$/)
       should contain_file('redis_port_8000.conf').with_content(/^auto-aof-rewrite-min-size 32mb$/)
       should contain_file('redis_port_8000.conf').with_content(/^aof-rewrite-incremental-fsync no$/)
+      should contain_file('redis_port_8000.conf').with_content(/^maxmemory-policy volatile-lru$/)
       should_not contain_file('redis_port_8000.conf').with_content(/^cluster-enabled$/)
     end # it
   end # context

--- a/templates/redis_port.conf.erb
+++ b/templates/redis_port.conf.erb
@@ -488,6 +488,7 @@ maxmemory <%= @redis_max_memory %>
 # The default is:
 #
 # maxmemory-policy noeviction
+maxmemory-policy <%= @redis_max_memory_policy %>
 
 # LRU and minimal TTL algorithms are not precise algorithms but approximated
 # algorithms (in order to save memory), so you can tune it for speed or

--- a/templates/redis_port.conf.erb
+++ b/templates/redis_port.conf.erb
@@ -646,6 +646,7 @@ lua-time-limit 5000
 # cluster node enable the cluster support uncommenting the following:
 #
 # cluster-enabled yes
+cluster-enabled <%= @redis_cluster_enabled ? 'yes' : 'no' %>
 <%- end -%>
 
 <%- if (version_c <=> [3,0,0]) >= 0 -%>
@@ -656,6 +657,7 @@ lua-time-limit 5000
 # overlapping cluster configuration file names.
 #
 # cluster-config-file nodes-6379.conf
+cluster-config-file <%= @redis_cluster_config_file %>
 <%- end -%>
 
 <%- if (version_c <=> [3,0,0]) >= 0 -%>
@@ -664,6 +666,7 @@ lua-time-limit 5000
 # Most other internal time limits are multiple of the node timeout.
 #
 # cluster-node-timeout 15000
+cluster-node-timeout <%= @redis_cluster_node_timeout %>
 <%- end -%>
 
 <%- if (version_c <=> [3,0,0]) >= 0 -%>
@@ -711,6 +714,7 @@ lua-time-limit 5000
 # the cluster will always be able to continue.
 #
 # cluster-slave-validity-factor 10
+cluster-slave-validity-factor <%= @redis_cluster_slave_validity_factor %>
 <%- end -%>
 
 <%- if (version_c <=> [3,0,0]) >= 0 -%>
@@ -732,6 +736,7 @@ lua-time-limit 5000
 # in production.
 #
 # cluster-migration-barrier 1
+cluster-migration-barrier <%= @redis_cluster_migration_barrier %>
 <%- end -%>
 
 <%- if (version_c <=> [3,0,0]) >= 0 -%>
@@ -747,6 +752,7 @@ lua-time-limit 5000
 # option to no.
 #
 # cluster-require-full-coverage yes
+cluster-require-full-coverage <%= @redis_cluster_require_full_coverage ? 'yes' : 'no' %>
 <%- end -%>
 
 # In order to setup your cluster make sure to read the documentation

--- a/templates/redis_port.conf.erb
+++ b/templates/redis_port.conf.erb
@@ -520,11 +520,11 @@ maxmemory <%= @redis_max_memory %>
 #
 # Please check http://redis.io/topics/persistence for more information.
 
-appendonly no
+appendonly <%= @redis_appendonly ? 'yes' : 'no' %>
 
 # The name of the append only file (default: "appendonly.aof")
 
-appendfilename "appendonly.aof"
+appendfilename "<%= @redis_appendfilename %>"
 
 # The fsync() call tells the Operating System to actually write data on disk
 # instead of waiting for more data in the output buffer. Some OS will really flush
@@ -550,7 +550,7 @@ appendfilename "appendonly.aof"
 # If unsure, use "everysec".
 
 # appendfsync always
-appendfsync everysec
+appendfsync <%= @redis_appendfsync %>
 # appendfsync no
 
 # When the AOF fsync policy is set to always or everysec, and a background
@@ -572,7 +572,7 @@ appendfsync everysec
 # If you have latency problems turn this to "yes". Otherwise leave it as
 # "no" that is the safest pick from the point of view of durability.
 
-no-appendfsync-on-rewrite no
+no-appendfsync-on-rewrite <%= @redis_no_appendfsync_on_rewrite ? 'yes' : 'no' %>
 
 # Automatic rewrite of the append only file.
 # Redis is able to automatically rewrite the log file implicitly calling
@@ -591,8 +591,8 @@ no-appendfsync-on-rewrite no
 # Specify a percentage of zero in order to disable the automatic AOF
 # rewrite feature.
 
-auto-aof-rewrite-percentage 100
-auto-aof-rewrite-min-size 64mb
+auto-aof-rewrite-percentage <%= @redis_auto_aof_rewrite_percentage %>
+auto-aof-rewrite-min-size <%= @redis_auto_aof_rewrite_min_size %>
 
 <%- if (version_c <=> [2,8,15]) >= 0 -%>
 # An AOF file may be found to be truncated at the end during the Redis
@@ -617,7 +617,7 @@ auto-aof-rewrite-min-size 64mb
 # the server will still exit with an error. This option only applies when
 # Redis will try to read more data from the AOF file but not enough bytes
 # will be found.
-aof-load-truncated yes
+aof-load-truncated <%= @redis_aof_load_truncated ? 'yes' : 'no' %>
 <%- end -%>
 
 ################################ LUA SCRIPTING  ###############################
@@ -968,4 +968,4 @@ hz 10
 # the file will be fsync-ed every 32 MB of data generated. This is useful
 # in order to commit the file to the disk more incrementally and avoid
 # big latency spikes.
-aof-rewrite-incremental-fsync yes
+aof-rewrite-incremental-fsync <%= @redis_aof_rewrite_incremental_fsync ? 'yes' : 'no' %>

--- a/templates/redis_port.conf.erb
+++ b/templates/redis_port.conf.erb
@@ -1,4 +1,6 @@
-# Note on units: when memory size is needed, it is possible to specifiy
+# Redis configuration file example
+
+# Note on units: when memory size is needed, it is possible to specify
 # it in the usual form of 1k 5GB 4M and so forth:
 #
 # 1k => 1000 bytes
@@ -24,6 +26,8 @@ port <%= @redis_port %>
 
 # If you want you can bind a single interface, if the bind option is not
 # specified all the interfaces will listen for incoming connections.
+#
+# bind 127.0.0.1
 <% if @redis_bind_address %>
 bind <%= @redis_bind_address %>
 <% end %>
@@ -33,12 +37,29 @@ bind <%= @redis_bind_address %>
 # on a unix socket when not specified.
 #
 # unixsocket /tmp/redis.sock
+# unixsocketperm 755
 
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout <%= @redis_timeout %>
 
-# Set server verbosity to 'debug'
-# it can be one of:
+# TCP keepalive.
+#
+# If non-zero, use SO_KEEPALIVE to send TCP ACKs to clients in absence
+# of communication. This is useful for two reasons:
+#
+# 1) Detect dead peers.
+# 2) Take the connection alive from the point of view of network
+#    equipment in the middle.
+#
+# On Linux, the specified value (in seconds) is the period used to send ACKs.
+# Note that to close the connection the double of the time is needed.
+# On other kernels the period depends on the kernel configuration.
+#
+# A reasonable value for this option is 60 seconds.
+tcp-keepalive 0
+
+# Specify the server verbosity level.
+# This can be one of:
 # debug (a lot of information, useful for development/testing)
 # verbose (many rarely useful info, but not a mess like the debug level)
 # notice (moderately verbose, what you want in production probably)
@@ -57,7 +78,7 @@ logfile /var/log/redis_<%= @redis_port %>.log
 # Specify the syslog identity.
 # syslog-ident redis
 
-# Specify the syslog facility.  Must be USER or between LOCAL0-LOCAL7.
+# Specify the syslog facility. Must be USER or between LOCAL0-LOCAL7.
 # syslog-facility local0
 
 # Set the number of databases. The default database is DB 0, you can select
@@ -79,17 +100,47 @@ databases <%= @redis_databases %>
 #   after 300 sec (5 min) if at least 10 keys changed
 #   after 60 sec if at least 10000 keys changed
 #
-#   Note: you can disable saving at all commenting all the save lines.
+#   Note: you can disable saving at all commenting all the "save" lines.
+#
+#   It is also possible to remove all the previously configured save
+#   points by adding a save directive with a single empty string argument
+#   like in the following example:
+#
+#   save ""
 
 <% if @redis_saves %>
 <%= @redis_saves.join("\n") %>
 <% end -%>
+
+# By default Redis will stop accepting writes if RDB snapshots are enabled
+# (at least one save point) and the latest background save failed.
+# This will make the user aware (in an hard way) that data is not persisting
+# on disk properly, otherwise chances are that no one will notice and some
+# distater will happen.
+#
+# If the background saving process will start working again Redis will
+# automatically allow writes again.
+#
+# However if you have setup your proper monitoring of the Redis server
+# and persistence, you may want to disable this feature so that Redis will
+# continue to work as usually even if there are problems with disk,
+# permissions, and so forth.
+stop-writes-on-bgsave-error yes
 
 # Compress string objects using LZF when dump .rdb databases?
 # For default that's set to 'yes' as it's almost always a win.
 # If you want to save some CPU in the saving child set it to 'no' but
 # the dataset will likely be bigger if you have compressible values or keys.
 rdbcompression yes
+
+# Since version 5 of RDB a CRC64 checksum is placed at the end of the file.
+# This makes the format more resistant to corruption but there is a performance
+# hit to pay (around 10%) when saving and loading RDB files, so you can disable it
+# for maximum performances.
+#
+# RDB files created with checksum disabled have a checksum of zero that will
+# tell the loading code to skip the check.
+rdbchecksum yes
 
 # The filename where to dump the DB
 dbfilename dump.rdb
@@ -98,9 +149,9 @@ dbfilename dump.rdb
 #
 # The DB will be written inside this directory, with the filename specified
 # above using the 'dbfilename' configuration directive.
-#
-# Also the Append Only File will be created inside this directory.
-#
+# 
+# The Append Only File will also be created inside this directory.
+# 
 # Note that you must specify a directory here, not a file name.
 dir /var/lib/redis/<%= @redis_port %>
 
@@ -113,103 +164,177 @@ dir /var/lib/redis/<%= @redis_port %>
 #
 # slaveof <masterip> <masterport>
 
-# If the master is password protected (using the requirepass configuration
+# If the master is password protected (using the "requirepass" configuration
 # directive below) it is possible to tell the slave to authenticate before
 # starting the replication synchronization process, otherwise the master will
 # refuse the slave request.
 #
 # masterauth <master-password>
 
-# When a slave lost the connection with the master, or when the replication
+# When a slave loses its connection with the master, or when the replication
 # is still in progress, the slave can act in two different ways:
 #
 # 1) if slave-serve-stale-data is set to 'yes' (the default) the slave will
-#    still reply to client requests, possibly with out of data data, or the
+#    still reply to client requests, possibly with out of date data, or the
 #    data set may just be empty if this is the first synchronization.
 #
-# 2) if slave-serve-stale data is set to 'no' the slave will reply with
-#    an error SYNC with master in progress to all the kind of commands
+# 2) if slave-serve-stale-data is set to 'no' the slave will reply with
+#    an error "SYNC with master in progress" to all the kind of commands
 #    but to INFO and SLAVEOF.
 #
 slave-serve-stale-data yes
+
+# You can configure a slave instance to accept writes or not. Writing against
+# a slave instance may be useful to store some ephemeral data (because data
+# written on a slave will be easily deleted after resync with the master) but
+# may also cause problems if clients are writing to it because of a
+# misconfiguration.
+#
+# Since Redis 2.6 by default slaves are read-only.
+#
+# Note: read only slaves are not designed to be exposed to untrusted clients
+# on the internet. It's just a protection layer against misuse of the instance.
+# Still a read only slave exports by default all the administrative commands
+# such as CONFIG, DEBUG, and so forth. To a limited extend you can improve
+# security of read only slaves using 'rename-command' to shadow all the
+# administrative / dangerous commands.
+slave-read-only yes
+
+# Slaves send PINGs to server in a predefined interval. It's possible to change
+# this interval with the repl_ping_slave_period option. The default value is 10
+# seconds.
+#
+# repl-ping-slave-period 10
+
+# The following option sets a timeout for both Bulk transfer I/O timeout and
+# master data or ping response timeout. The default value is 60 seconds.
+#
+# It is important to make sure that this value is greater than the value
+# specified for repl-ping-slave-period otherwise a timeout will be detected
+# every time there is low traffic between the master and the slave.
+#
+# repl-timeout 60
+
+# Disable TCP_NODELAY on the slave socket after SYNC?
+#
+# If you select "yes" Redis will use a smaller number of TCP packets and
+# less bandwidth to send data to slaves. But this can add a delay for
+# the data to appear on the slave side, up to 40 milliseconds with
+# Linux kernels using a default configuration.
+#
+# If you select "no" the delay for data to appear on the slave side will
+# be reduced but more bandwidth will be used for replication.
+#
+# By default we optimize for low latency, but in very high traffic conditions
+# or when the master and slaves are many hops away, turning this to "yes" may
+# be a good idea.
+repl-disable-tcp-nodelay no
+
+# The slave priority is an integer number published by Redis in the INFO output.
+# It is used by Redis Sentinel in order to select a slave to promote into a
+# master if the master is no longer working correctly.
+#
+# A slave with a low priority number is considered better for promotion, so
+# for instance if there are three slaves with priority 10, 100, 25 Sentinel will
+# pick the one wtih priority 10, that is the lowest.
+#
+# However a special priority of 0 marks the slave as not able to perform the
+# role of master, so a slave with priority of 0 will never be selected by
+# Redis Sentinel for promotion.
+#
+# By default the priority is 100.
+slave-priority 100
 
 ################################## SECURITY ###################################
 
 # Require clients to issue AUTH <PASSWORD> before processing any other
 # commands.  This might be useful in environments in which you do not trust
-# others with access to the host running redis.
+# others with access to the host running redis-server.
 #
 # This should stay commented out for backward compatibility and because most
 # people do not need auth (e.g. they run their own servers).
-#
+# 
 # Warning: since Redis is pretty fast an outside user can try up to
 # 150k passwords per second against a good box. This means that you should
 # use a very strong password otherwise it will be very easy to break.
 #
+# requirepass foobared
 <% if @redis_password %>
 requirepass <%= @redis_password %>
 <% end %>
 
 # Command renaming.
 #
-# It is possilbe to change the name of dangerous commands in a shared
+# It is possible to change the name of dangerous commands in a shared
 # environment. For instance the CONFIG command may be renamed into something
-# of hard to guess so that it will be still available for internal-use
-# tools but not available for general clients.
+# hard to guess so that it will still be available for internal-use tools
+# but not available for general clients.
 #
 # Example:
 #
 # rename-command CONFIG b840fc02d524045429941cc15f59e41cb7be6c52
 #
-# It is also possilbe to completely kill a command renaming it into
+# It is also possible to completely kill a command by renaming it into
 # an empty string:
 #
-# rename-command CONFIG 
+# rename-command CONFIG ""
+#
+# Please note that changing the name of commands that are logged into the
+# AOF file or transmitted to slaves may cause problems.
 
 ################################### LIMITS ####################################
 
-# Set the max number of connected clients at the same time. By default there
-# is no limit, and it's up to the number of file descriptors the Redis process
-# is able to open. The special value '0' means no limits.
+# Set the max number of connected clients at the same time. By default
+# this limit is set to 10000 clients, however if the Redis server is not
+# able to configure the process file limit to allow for the specified limit
+# the max number of allowed clients is set to the current file limit
+# minus 32 (as Redis reserves a few file descriptors for internal uses).
+#
 # Once the limit is reached Redis will close all the new connections sending
 # an error 'max number of clients reached'.
 #
-# maxclients 128
+# maxclients 10000
 <% if @redis_max_clients %>
 maxclients <%= @redis_max_clients %>
 <% end %>
 
 # Don't use more memory than the specified amount of bytes.
-# When the memory limit is reached Redis will try to remove keys with an
-# EXPIRE set. It will try to start freeing keys that are going to expire
-# in little time and preserve keys with a longer time to live.
-# Redis will also try to remove objects from free lists if possible.
+# When the memory limit is reached Redis will try to remove keys
+# accordingly to the eviction policy selected (see maxmemmory-policy).
 #
-# If all this fails, Redis will start to reply with errors to commands
-# that will use more memory, like SET, LPUSH, and so on, and will continue
-# to reply to most read-only commands like GET.
+# If Redis can't remove keys according to the policy, or if the policy is
+# set to 'noeviction', Redis will start to reply with errors to commands
+# that would use more memory, like SET, LPUSH, and so on, and will continue
+# to reply to read-only commands like GET.
 #
-# WARNING: maxmemory can be a good idea mainly if you want to use Redis as a
-# 'state' server or cache, not as a real DB. When Redis is used as a real
-# database the memory usage will grow over the weeks, it will be obvious if
-# it is going to use too much memory in the long run, and you'll have the time
-# to upgrade. With maxmemory after the limit is reached you'll start to get
-# errors for write operations, and this may even lead to DB inconsistency.
+# This option is usually useful when using Redis as an LRU cache, or to set
+# an hard memory limit for an instance (using the 'noeviction' policy).
+#
+# WARNING: If you have slaves attached to an instance with maxmemory on,
+# the size of the output buffers needed to feed the slaves are subtracted
+# from the used memory count, so that network problems / resyncs will
+# not trigger a loop where keys are evicted, and in turn the output
+# buffer of slaves is full with DELs of keys evicted triggering the deletion
+# of more keys, and so forth until the database is completely emptied.
+#
+# In short... if you have slaves attached it is suggested that you set a lower
+# limit for maxmemory so that there is some free RAM on the system for slave
+# output buffers (but this is not needed if the policy is 'noeviction').
 #
 # maxmemory <bytes>
 maxmemory <%= @redis_max_memory %>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
-# is reached? You can select among five behavior:
-#
+# is reached. You can select among five behaviors:
+# 
 # volatile-lru -> remove the key with an expire set using an LRU algorithm
 # allkeys-lru -> remove any key accordingly to the LRU algorithm
 # volatile-random -> remove a random key with an expire set
-# allkeys->random -> remove a random key, any key
+# allkeys-random -> remove a random key, any key
 # volatile-ttl -> remove the key with the nearest expire time (minor TTL)
 # noeviction -> don't expire at all, just return an error on write operations
-#
-# Note: with all the kind of policies, Redis will return an error on write
+# 
+# Note: with any of the above policies, Redis will return an error on write
 #       operations, when there are not suitable keys for eviction.
 #
 #       At the date of writing this commands are: set setnx setex append
@@ -232,46 +357,51 @@ maxmemory <%= @redis_max_memory %>
 
 ############################## APPEND ONLY MODE ###############################
 
-# By default Redis asynchronously dumps the dataset on disk. If you can live
-# with the idea that the latest records will be lost if something like a crash
-# happens this is the preferred way to run Redis. If instead you care a lot
-# about your data and don't want to that a single record can get lost you should
-# enable the append only mode: when this mode is enabled Redis will append
-# every write operation received in the file appendonly.aof. This file will
-# be read on startup in order to rebuild the full dataset in memory.
+# By default Redis asynchronously dumps the dataset on disk. This mode is
+# good enough in many applications, but an issue with the Redis process or
+# a power outage may result into a few minutes of writes lost (depending on
+# the configured save points).
 #
-# Note that you can have both the async dumps and the append only file if you
-# like (you have to comment the save statements above to disable the dumps).
-# Still if append only mode is enabled Redis will load the data from the
-# log file at startup ignoring the dump.rdb file.
+# The Append Only File is an alternative persistence mode that provides
+# much better durability. For instance using the default data fsync policy
+# (see later in the config file) Redis can lose just one second of writes in a
+# dramatic event like a server power outage, or a single write if something
+# wrong with the Redis process itself happens, but the operating system is
+# still running correctly.
 #
-# IMPORTANT: Check the BGREWRITEAOF to check how to rewrite the append
-# log file in background when it gets too big.
+# AOF and RDB persistence can be enabled at the same time without problems.
+# If the AOF is enabled on startup Redis will load the AOF, that is the file
+# with the better durability guarantees.
+#
+# Please check http://redis.io/topics/persistence for more information.
 
 appendonly no
 
-# The name of the append only file (default: appendonly.aof)
+# The name of the append only file (default: "appendonly.aof")
 # appendfilename appendonly.aof
 
 # The fsync() call tells the Operating System to actually write data on disk
-# instead to wait for more data in the output buffer. Some OS will really flush
+# instead to wait for more data in the output buffer. Some OS will really flush 
 # data on disk, some other OS will just try to do it ASAP.
 #
 # Redis supports three different modes:
 #
 # no: don't fsync, just let the OS flush the data when it wants. Faster.
 # always: fsync after every write to the append only log . Slow, Safest.
-# everysec: fsync only if one second passed since the last fsync. Compromise.
+# everysec: fsync only one time every second. Compromise.
 #
-# The default is everysec that's usually the right compromise between
+# The default is "everysec", as that's usually the right compromise between
 # speed and data safety. It's up to you to understand if you can relax this to
-# no that will will let the operating system flush the output buffer when
+# "no" that will let the operating system flush the output buffer when
 # it wants, for better performances (but if you can live with the idea of
 # some data loss consider the default persistence mode that's snapshotting),
-# or on the contrary, use always that's very slow but a bit safer than
+# or on the contrary, use "always" that's very slow but a bit safer than
 # everysec.
 #
-# If unsure, use everysec.
+# More details please check the following article:
+# http://antirez.com/post/redis-persistence-demystified.html
+#
+# If unsure, use "everysec".
 
 # appendfsync always
 appendfsync everysec
@@ -288,21 +418,21 @@ appendfsync everysec
 # that will prevent fsync() from being called in the main process while a
 # BGSAVE or BGREWRITEAOF is in progress.
 #
-# This means that while another child is saving the durability of Redis is
-# the same as appendfsync none, that in pratical terms means that it is
-# possible to lost up to 30 seconds of log in the worst scenario (with the
+# This means that while another child is saving, the durability of Redis is
+# the same as "appendfsync none". In practical terms, this means that it is
+# possible to lose up to 30 seconds of log in the worst scenario (with the
 # default Linux settings).
-#
-# If you have latency problems turn this to yes. Otherwise leave it as
-# no that is the safest pick from the point of view of durability.
+# 
+# If you have latency problems turn this to "yes". Otherwise leave it as
+# "no" that is the safest pick from the point of view of durability.
 no-appendfsync-on-rewrite no
 
 # Automatic rewrite of the append only file.
 # Redis is able to automatically rewrite the log file implicitly calling
-# BGREWRITEAOF when the AOF log size will growth by the specified percentage.
-#
+# BGREWRITEAOF when the AOF log size grows by the specified percentage.
+# 
 # This is how it works: Redis remembers the size of the AOF file after the
-# latest rewrite (or if no rewrite happened since the restart, the size of
+# latest rewrite (if no rewrite has happened since the restart, the size of
 # the AOF at startup is used).
 #
 # This base size is compared to the current size. If the current size is
@@ -311,7 +441,7 @@ no-appendfsync-on-rewrite no
 # is useful to avoid rewriting the AOF file even if the percentage increase
 # is reached but it is still pretty small.
 #
-# Specify a precentage of zero in order to disable the automatic AOF
+# Specify a percentage of zero in order to disable the automatic AOF
 # rewrite feature.
 
 auto-aof-rewrite-percentage 100
@@ -320,9 +450,20 @@ auto-aof-rewrite-min-size 64mb
 ################################ LUA SCRIPTING  ###############################
 
 # Max execution time of a Lua script in milliseconds.
-# This prevents that a programming error generating an infinite loop will block
-# your server forever. Set it to 0 or a negative value for unlimited execution.
-#lua-time-limit 60000
+#
+# If the maximum execution time is reached Redis will log that a script is
+# still in execution after the maximum allowed time and will start to
+# reply to queries with an error.
+#
+# When a long running script exceed the maximum execution time only the
+# SCRIPT KILL and SHUTDOWN NOSAVE commands are available. The first can be
+# used to stop a script that did not yet called write commands. The second
+# is the only way to shut down the server in the case a write commands was
+# already issue by the script but the user don't want to wait for the natural
+# termination of the script.
+#
+# Set it to 0 or a negative value for unlimited execution without warnings.
+lua-time-limit 5000
 
 ################################## SLOW LOG ###################################
 
@@ -332,7 +473,7 @@ auto-aof-rewrite-min-size 64mb
 # but just the time needed to actually execute the command (this is the only
 # stage of command execution where the thread is blocked and can not serve
 # other requests in the meantime).
-#
+# 
 # You can configure the slow log with two parameters: one tells Redis
 # what is the execution time, in microseconds, to exceed in order for the
 # command to get logged, and the other parameter is the length of the
@@ -350,10 +491,9 @@ slowlog-max-len <%= @redis_slowlog_max_len %>
 
 ############################### ADVANCED CONFIG ###############################
 
-# Hashes are encoded in a special way (much more memory efficient) when they
-# have at max a given numer of elements, and the biggest element does not
-# exceed a given threshold. You can configure this limits with the following
-# configuration directives.
+# Hashes are encoded using a memory efficient data structure when they have a
+# small number of entries, and the biggest entry does not exceed a given
+# threshold. These thresholds can be configured using the following directives.
 hash-max-ziplist-entries 512
 hash-max-ziplist-value 64
 
@@ -378,28 +518,88 @@ zset-max-ziplist-value 64
 
 # Active rehashing uses 1 millisecond every 100 milliseconds of CPU time in
 # order to help rehashing the main Redis hash table (the one mapping top-level
-# keys to values). The hash table implementation redis uses (see dict.c)
+# keys to values). The hash table implementation Redis uses (see dict.c)
 # performs a lazy rehashing: the more operation you run into an hash table
-# that is rhashing, the more rehashing steps are performed, so if the
+# that is rehashing, the more rehashing "steps" are performed, so if the
 # server is idle the rehashing is never complete and some more memory is used
 # by the hash table.
-#
+# 
 # The default is to use this millisecond 10 times every second in order to
 # active rehashing the main dictionaries, freeing memory when possible.
 #
 # If unsure:
-# use activerehashing no if you have hard latency requirements and it is
+# use "activerehashing no" if you have hard latency requirements and it is
 # not a good thing in your environment that Redis can reply form time to time
 # to queries with 2 milliseconds delay.
 #
-# use activerehashing yes if you don't have such hard requirements but
+# use "activerehashing yes" if you don't have such hard requirements but
 # want to free memory asap when possible.
 activerehashing yes
+
+# The client output buffer limits can be used to force disconnection of clients
+# that are not reading data from the server fast enough for some reason (a
+# common reason is that a Pub/Sub client can't consume messages as fast as the
+# publisher can produce them).
+#
+# The limit can be set differently for the three different classes of clients:
+#
+# normal -> normal clients
+# slave  -> slave clients and MONITOR clients
+# pubsub -> clients subcribed to at least one pubsub channel or pattern
+#
+# The syntax of every client-output-buffer-limit directive is the following:
+#
+# client-output-buffer-limit <class> <hard limit> <soft limit> <soft seconds>
+#
+# A client is immediately disconnected once the hard limit is reached, or if
+# the soft limit is reached and remains reached for the specified number of
+# seconds (continuously).
+# So for instance if the hard limit is 32 megabytes and the soft limit is
+# 16 megabytes / 10 seconds, the client will get disconnected immediately
+# if the size of the output buffers reach 32 megabytes, but will also get
+# disconnected if the client reaches 16 megabytes and continuously overcomes
+# the limit for 10 seconds.
+#
+# By default normal clients are not limited because they don't receive data
+# without asking (in a push way), but just after a request, so only
+# asynchronous clients may create a scenario where data is requested faster
+# than it can read.
+#
+# Instead there is a default limit for pubsub and slave clients, since
+# subscribers and slaves receive data in a push fashion.
+#
+# Both the hard or the soft limit can be disabled by setting them to zero.
+client-output-buffer-limit normal 0 0 0
+client-output-buffer-limit slave 256mb 64mb 60
+client-output-buffer-limit pubsub 32mb 8mb 60
+
+# Redis calls an internal function to perform many background tasks, like
+# closing connections of clients in timeot, purging expired keys that are
+# never requested, and so forth.
+#
+# Not all tasks are perforemd with the same frequency, but Redis checks for
+# tasks to perform accordingly to the specified "hz" value.
+#
+# By default "hz" is set to 10. Raising the value will use more CPU when
+# Redis is idle, but at the same time will make Redis more responsive when
+# there are many keys expiring at the same time, and timeouts may be
+# handled with more precision.
+#
+# The range is between 1 and 500, however a value over 100 is usually not
+# a good idea. Most users should use the default of 10 and raise this up to
+# 100 only in environments where very low latency is required.
+hz 10
+
+# When a child rewrites the AOF file, if the following option is enabled
+# the file will be fsync-ed every 32 MB of data generated. This is useful
+# in order to commit the file to the disk more incrementally and avoid
+# big latency spikes.
+aof-rewrite-incremental-fsync yes
 
 ################################## INCLUDES ###################################
 
 # Include one or more other config files here.  This is useful if you
-# have a standard template that goes to all redis server but also need
+# have a standard template that goes to all Redis server but also need
 # to customize a few per-server settings.  Include files can include
 # other files, so use this wisely.
 #

--- a/templates/redis_port.conf.erb
+++ b/templates/redis_port.conf.erb
@@ -487,15 +487,18 @@ maxmemory <%= @redis_max_memory %>
 #
 # The default is:
 #
-# maxmemory-policy volatile-lru
+# maxmemory-policy noeviction
 
 # LRU and minimal TTL algorithms are not precise algorithms but approximated
-# algorithms (in order to save memory), so you can select as well the sample
-# size to check. For instance for default Redis will check three keys and
-# pick the one that was used less recently, you can change the sample size
-# using the following configuration directive.
+# algorithms (in order to save memory), so you can tune it for speed or
+# accuracy. For default Redis will check five keys and pick the one that was
+# used less recently, you can change the sample size using the following
+# configuration directive.
 #
-# maxmemory-samples 3
+# The default of 5 produces good enough results. 10 Approximates very closely
+# true LRU but costs a bit more CPU. 3 is very fast but not very accurate.
+#
+# maxmemory-samples 5
 
 ############################## APPEND ONLY MODE ###############################
 
@@ -634,6 +637,120 @@ aof-load-truncated yes
 #
 # Set it to 0 or a negative value for unlimited execution without warnings.
 lua-time-limit 5000
+
+################################ REDIS CLUSTER  ###############################
+
+<%- if (version_c <=> [3,0,0]) >= 0 -%>
+# Normal Redis instances can't be part of a Redis Cluster; only nodes that are
+# started as cluster nodes can. In order to start a Redis instance as a
+# cluster node enable the cluster support uncommenting the following:
+#
+# cluster-enabled yes
+<%- end -%>
+
+<%- if (version_c <=> [3,0,0]) >= 0 -%>
+# Every cluster node has a cluster configuration file. This file is not
+# intended to be edited by hand. It is created and updated by Redis nodes.
+# Every Redis Cluster node requires a different cluster configuration file.
+# Make sure that instances running in the same system do not have
+# overlapping cluster configuration file names.
+#
+# cluster-config-file nodes-6379.conf
+<%- end -%>
+
+<%- if (version_c <=> [3,0,0]) >= 0 -%>
+# Cluster node timeout is the amount of milliseconds a node must be unreachable
+# for it to be considered in failure state.
+# Most other internal time limits are multiple of the node timeout.
+#
+# cluster-node-timeout 15000
+<%- end -%>
+
+<%- if (version_c <=> [3,0,0]) >= 0 -%>
+# A slave of a failing master will avoid to start a failover if its data
+# looks too old.
+#
+# There is no simple way for a slave to actually have a exact measure of
+# its "data age", so the following two checks are performed:
+#
+# 1) If there are multiple slaves able to failover, they exchange messages
+#    in order to try to give an advantage to the slave with the best
+#    replication offset (more data from the master processed).
+#    Slaves will try to get their rank by offset, and apply to the start
+#    of the failover a delay proportional to their rank.
+#
+# 2) Every single slave computes the time of the last interaction with
+#    its master. This can be the last ping or command received (if the master
+#    is still in the "connected" state), or the time that elapsed since the
+#    disconnection with the master (if the replication link is currently down).
+#    If the last interaction is too old, the slave will not try to failover
+#    at all.
+#
+# The point "2" can be tuned by user. Specifically a slave will not perform
+# the failover if, since the last interaction with the master, the time
+# elapsed is greater than:
+#
+#   (node-timeout * slave-validity-factor) + repl-ping-slave-period
+#
+# So for example if node-timeout is 30 seconds, and the slave-validity-factor
+# is 10, and assuming a default repl-ping-slave-period of 10 seconds, the
+# slave will not try to failover if it was not able to talk with the master
+# for longer than 310 seconds.
+#
+# A large slave-validity-factor may allow slaves with too old data to failover
+# a master, while a too small value may prevent the cluster from being able to
+# elect a slave at all.
+#
+# For maximum availability, it is possible to set the slave-validity-factor
+# to a value of 0, which means, that slaves will always try to failover the
+# master regardless of the last time they interacted with the master.
+# (However they'll always try to apply a delay proportional to their
+# offset rank).
+#
+# Zero is the only value able to guarantee that when all the partitions heal
+# the cluster will always be able to continue.
+#
+# cluster-slave-validity-factor 10
+<%- end -%>
+
+<%- if (version_c <=> [3,0,0]) >= 0 -%>
+# Cluster slaves are able to migrate to orphaned masters, that are masters
+# that are left without working slaves. This improves the cluster ability
+# to resist to failures as otherwise an orphaned master can't be failed over
+# in case of failure if it has no working slaves.
+#
+# Slaves migrate to orphaned masters only if there are still at least a
+# given number of other working slaves for their old master. This number
+# is the "migration barrier". A migration barrier of 1 means that a slave
+# will migrate only if there is at least 1 other working slave for its master
+# and so forth. It usually reflects the number of slaves you want for every
+# master in your cluster.
+#
+# Default is 1 (slaves migrate only if their masters remain with at least
+# one slave). To disable migration just set it to a very large value.
+# A value of 0 can be set but is useful only for debugging and dangerous
+# in production.
+#
+# cluster-migration-barrier 1
+<%- end -%>
+
+<%- if (version_c <=> [3,0,0]) >= 0 -%>
+# By default Redis Cluster nodes stop accepting queries if they detect there
+# is at least an hash slot uncovered (no available node is serving it).
+# This way if the cluster is partially down (for example a range of hash slots
+# are no longer covered) all the cluster becomes, eventually, unavailable.
+# It automatically returns available as soon as all the slots are covered again.
+#
+# However sometimes you want the subset of the cluster which is working,
+# to continue to accept queries for the part of the key space that is still
+# covered. In order to do so, just set the cluster-require-full-coverage
+# option to no.
+#
+# cluster-require-full-coverage yes
+<%- end -%>
+
+# In order to setup your cluster make sure to read the documentation
+# available at http://redis.io web site.
 
 ################################## SLOW LOG ###################################
 

--- a/templates/redis_port.conf.erb
+++ b/templates/redis_port.conf.erb
@@ -1,3 +1,4 @@
+<%- version_c = @version.split('.').map(&:to_i) -%>
 # Redis configuration file example
 
 # Note on units: when memory size is needed, it is possible to specify
@@ -12,6 +13,26 @@
 #
 # units are case insensitive so 1GB 1Gb 1gB are all the same.
 
+################################## INCLUDES ###################################
+
+# Include one or more other config files here.  This is useful if you
+# have a standard template that goes to all Redis servers but also need
+# to customize a few per-server settings.  Include files can include
+# other files, so use this wisely.
+#
+# Notice option "include" won't be rewritten by command "CONFIG REWRITE"
+# from admin or Redis Sentinel. Since Redis always uses the last processed
+# line as value of a configuration directive, you'd better put includes
+# at the beginning of this file to avoid overwriting config change at runtime.
+#
+# If instead you are interested in using includes to override configuration
+# options, it is better to use include as the last line.
+#
+# include /path/to/local.conf
+# include /path/to/other.conf
+
+################################ GENERAL  #####################################
+
 # By default Redis does not run as a daemon. Use 'yes' if you need it.
 # Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
 daemonize yes
@@ -24,20 +45,36 @@ pidfile /var/run/redis_<%= @redis_port %>.pid
 # If port 0 is specified Redis will not listen on a TCP socket.
 port <%= @redis_port %>
 
-# If you want you can bind a single interface, if the bind option is not
-# specified all the interfaces will listen for incoming connections.
+<%- if (version_c <=> [2,8,5]) >= 0 -%>
+# TCP listen() backlog.
 #
+# In high requests-per-second environments you need an high backlog in order
+# to avoid slow clients connections issues. Note that the Linux kernel
+# will silently truncate it to the value of /proc/sys/net/core/somaxconn so
+# make sure to raise both the value of somaxconn and tcp_max_syn_backlog
+# in order to get the desired effect.
+tcp-backlog 511
+<%- end -%>
+
+# By default Redis listens for connections from all the network interfaces
+# available on the server. It is possible to listen to just one or multiple
+# interfaces using the "bind" configuration directive, followed by one or
+# more IP addresses.
+#
+# Examples:
+#
+# bind 192.168.1.100 10.0.0.1
 # bind 127.0.0.1
 <% if @redis_bind_address %>
 bind <%= @redis_bind_address %>
 <% end %>
 
-# Specify the path for the unix socket that will be used to listen for
+# Specify the path for the Unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen
 # on a unix socket when not specified.
 #
 # unixsocket /tmp/redis.sock
-# unixsocketperm 755
+# unixsocketperm 700
 
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout <%= @redis_timeout %>
@@ -66,7 +103,7 @@ tcp-keepalive 0
 # warning (only very important / critical messages are logged)
 loglevel <%= @redis_loglevel %>
 
-# Specify the log file name. Also 'stdout' can be used to force
+# Specify the log file name. Also the empty string can be used to force
 # Redis to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null
 logfile /var/log/redis_<%= @redis_port %>.log
@@ -86,7 +123,7 @@ logfile /var/log/redis_<%= @redis_port %>.log
 # dbid is a number between 0 and 'databases'-1
 databases <%= @redis_databases %>
 
-################################ SNAPSHOTTING  #################################
+################################ SNAPSHOTTING  ################################
 #
 # Save the DB on disk:
 #
@@ -100,7 +137,7 @@ databases <%= @redis_databases %>
 #   after 300 sec (5 min) if at least 10 keys changed
 #   after 60 sec if at least 10000 keys changed
 #
-#   Note: you can disable saving at all commenting all the "save" lines.
+#   Note: you can disable saving completely by commenting out all "save" lines.
 #
 #   It is also possible to remove all the previously configured save
 #   points by adding a save directive with a single empty string argument
@@ -114,16 +151,16 @@ databases <%= @redis_databases %>
 
 # By default Redis will stop accepting writes if RDB snapshots are enabled
 # (at least one save point) and the latest background save failed.
-# This will make the user aware (in an hard way) that data is not persisting
+# This will make the user aware (in a hard way) that data is not persisting
 # on disk properly, otherwise chances are that no one will notice and some
-# distater will happen.
+# disaster will happen.
 #
 # If the background saving process will start working again Redis will
 # automatically allow writes again.
 #
 # However if you have setup your proper monitoring of the Redis server
 # and persistence, you may want to disable this feature so that Redis will
-# continue to work as usually even if there are problems with disk,
+# continue to work as usual even if there are problems with disk,
 # permissions, and so forth.
 stop-writes-on-bgsave-error yes
 
@@ -149,18 +186,27 @@ dbfilename dump.rdb
 #
 # The DB will be written inside this directory, with the filename specified
 # above using the 'dbfilename' configuration directive.
-# 
+#
 # The Append Only File will also be created inside this directory.
-# 
+#
 # Note that you must specify a directory here, not a file name.
 dir /var/lib/redis/<%= @redis_port %>
 
 ################################# REPLICATION #################################
 
 # Master-Slave replication. Use slaveof to make a Redis instance a copy of
-# another Redis server. Note that the configuration is local to the slave
-# so for example it is possible to configure the slave to save the DB with a
-# different interval, or to listen to another port, and so on.
+# another Redis server. A few things to understand ASAP about Redis replication.
+#
+# 1) Redis replication is asynchronous, but you can configure a master to
+#    stop accepting writes if it appears to be not connected with at least
+#    a given number of slaves.
+# 2) Redis slaves are able to perform a partial resynchronization with the
+#    master if the replication link is lost for a relatively small amount of
+#    time. You may want to configure the replication backlog size (see the next
+#    sections of this file) with a sensible value depending on your needs.
+# 3) Replication is automatic and does not need user intervention. After a
+#    network partition slaves automatically try to reconnect to masters
+#    and resynchronize with them.
 #
 # slaveof <masterip> <masterport>
 
@@ -195,10 +241,53 @@ slave-serve-stale-data yes
 # Note: read only slaves are not designed to be exposed to untrusted clients
 # on the internet. It's just a protection layer against misuse of the instance.
 # Still a read only slave exports by default all the administrative commands
-# such as CONFIG, DEBUG, and so forth. To a limited extend you can improve
+# such as CONFIG, DEBUG, and so forth. To a limited extent you can improve
 # security of read only slaves using 'rename-command' to shadow all the
 # administrative / dangerous commands.
 slave-read-only yes
+
+<%- if version_c[0] == 2 && (version_c <=> [2,8,17]) > 0 -%>
+# Replication SYNC strategy: disk or socket.
+#
+# New slaves and reconnecting slaves that are not able to continue the replication
+# process just receiving differences, need to do what is called a "full
+# synchronization". An RDB file is transmitted from the master to the slaves.
+# The transmission can happen in two different ways:
+#
+# 1) Disk-backed: The Redis master creates a new process that writes the RDB
+#                 file on disk. Later the file is transferred by the parent
+#                 process to the slaves incrementally.
+# 2) Diskless: The Redis master creates a new process that directly writes the
+#              RDB file to slave sockets, without touching the disk at all.
+#
+# With disk-backed replication, while the RDB file is generated, more slaves
+# can be queued and served with the RDB file as soon as the current child producing
+# the RDB file finishes its work. With diskless replication instead once
+# the transfer starts, new slaves arriving will be queued and a new transfer
+# will start when the current one terminates.
+#
+# When diskless replication is used, the master waits a configurable amount of
+# time (in seconds) before starting the transfer in the hope that multiple slaves
+# will arrive and the transfer can be parallelized.
+#
+# With slow disks and fast (large bandwidth) networks, diskless replication
+# works better.
+repl-diskless-sync no
+<%- end -%>
+
+<%- if version_c[0] == 2 && (version_c <=> [2,8,17]) > 0 -%>
+# When diskless replication is enabled, it is possible to configure the delay
+# the server waits in order to spawn the child that trnasfers the RDB via socket
+# to the slaves.
+#
+# This is important since once the transfer starts, it is not possible to serve
+# new slaves arriving, that will be queued for the next RDB transfer, so the server
+# waits a delay in order to let more slaves arrive.
+#
+# The delay is specified in seconds, and by default is 5 seconds. To disable
+# it entirely just set it to 0 seconds and the transfer will start ASAP.
+repl-diskless-sync-delay 5
+<%- end -%>
 
 # Slaves send PINGs to server in a predefined interval. It's possible to change
 # this interval with the repl_ping_slave_period option. The default value is 10
@@ -206,8 +295,11 @@ slave-read-only yes
 #
 # repl-ping-slave-period 10
 
-# The following option sets a timeout for both Bulk transfer I/O timeout and
-# master data or ping response timeout. The default value is 60 seconds.
+# The following option sets the replication timeout for:
+#
+# 1) Bulk transfer I/O during SYNC, from the point of view of slave.
+# 2) Master timeout from the point of view of slaves (data, pings).
+# 3) Slave timeout from the point of view of masters (REPLCONF ACK pings).
 #
 # It is important to make sure that this value is greater than the value
 # specified for repl-ping-slave-period otherwise a timeout will be detected
@@ -230,13 +322,39 @@ slave-read-only yes
 # be a good idea.
 repl-disable-tcp-nodelay no
 
+<%- if (version_c <=> [2,8,0]) >= 0 -%>
+# Set the replication backlog size. The backlog is a buffer that accumulates
+# slave data when slaves are disconnected for some time, so that when a slave
+# wants to reconnect again, often a full resync is not needed, but a partial
+# resync is enough, just passing the portion of data the slave missed while
+# disconnected.
+#
+# The bigger the replication backlog, the longer the time the slave can be
+# disconnected and later be able to perform a partial resynchronization.
+#
+# The backlog is only allocated once there is at least a slave connected.
+#
+# repl-backlog-size 1mb
+<%- end -%>
+
+<%- if (version_c <=> [2,8,0]) >= 0 -%>
+# After a master has no longer connected slaves for some time, the backlog
+# will be freed. The following option configures the amount of seconds that
+# need to elapse, starting from the time the last slave disconnected, for
+# the backlog buffer to be freed.
+#
+# A value of 0 means to never release the backlog.
+#
+# repl-backlog-ttl 3600
+<%- end -%>
+
 # The slave priority is an integer number published by Redis in the INFO output.
 # It is used by Redis Sentinel in order to select a slave to promote into a
 # master if the master is no longer working correctly.
 #
 # A slave with a low priority number is considered better for promotion, so
 # for instance if there are three slaves with priority 10, 100, 25 Sentinel will
-# pick the one wtih priority 10, that is the lowest.
+# pick the one with priority 10, that is the lowest.
 #
 # However a special priority of 0 marks the slave as not able to perform the
 # role of master, so a slave with priority of 0 will never be selected by
@@ -244,6 +362,30 @@ repl-disable-tcp-nodelay no
 #
 # By default the priority is 100.
 slave-priority 100
+
+<%- if (version_c <=> [2,8,0]) >= 0 -%>
+# It is possible for a master to stop accepting writes if there are less than
+# N slaves connected, having a lag less or equal than M seconds.
+#
+# The N slaves need to be in "online" state.
+#
+# The lag in seconds, that must be <= the specified value, is calculated from
+# the last ping received from the slave, that is usually sent every second.
+#
+# This option does not GUARANTEE that N replicas will accept the write, but
+# will limit the window of exposure for lost writes in case not enough slaves
+# are available, to the specified number of seconds.
+#
+# For example to require at least 3 slaves with a lag <= 10 seconds use:
+#
+# min-slaves-to-write 3
+# min-slaves-max-lag 10
+#
+# Setting one or the other to 0 disables the feature.
+#
+# By default min-slaves-to-write is set to 0 (feature disabled) and
+# min-slaves-max-lag is set to 10.
+<%- end -%>
 
 ################################## SECURITY ###################################
 
@@ -253,7 +395,7 @@ slave-priority 100
 #
 # This should stay commented out for backward compatibility and because most
 # people do not need auth (e.g. they run their own servers).
-# 
+#
 # Warning: since Redis is pretty fast an outside user can try up to
 # 150k passwords per second against a good box. This means that you should
 # use a very strong password otherwise it will be very easy to break.
@@ -300,7 +442,7 @@ maxclients <%= @redis_max_clients %>
 
 # Don't use more memory than the specified amount of bytes.
 # When the memory limit is reached Redis will try to remove keys
-# accordingly to the eviction policy selected (see maxmemmory-policy).
+# according to the eviction policy selected (see maxmemory-policy).
 #
 # If Redis can't remove keys according to the policy, or if the policy is
 # set to 'noeviction', Redis will start to reply with errors to commands
@@ -308,7 +450,7 @@ maxclients <%= @redis_max_clients %>
 # to reply to read-only commands like GET.
 #
 # This option is usually useful when using Redis as an LRU cache, or to set
-# an hard memory limit for an instance (using the 'noeviction' policy).
+# a hard memory limit for an instance (using the 'noeviction' policy).
 #
 # WARNING: If you have slaves attached to an instance with maxmemory on,
 # the size of the output buffers needed to feed the slaves are subtracted
@@ -326,18 +468,18 @@ maxmemory <%= @redis_max_memory %>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached. You can select among five behaviors:
-# 
+#
 # volatile-lru -> remove the key with an expire set using an LRU algorithm
-# allkeys-lru -> remove any key accordingly to the LRU algorithm
+# allkeys-lru -> remove any key according to the LRU algorithm
 # volatile-random -> remove a random key with an expire set
 # allkeys-random -> remove a random key, any key
 # volatile-ttl -> remove the key with the nearest expire time (minor TTL)
 # noeviction -> don't expire at all, just return an error on write operations
-# 
-# Note: with any of the above policies, Redis will return an error on write
-#       operations, when there are not suitable keys for eviction.
 #
-#       At the date of writing this commands are: set setnx setex append
+# Note: with any of the above policies, Redis will return an error on write
+#       operations, when there are no suitable keys for eviction.
+#
+#       At the date of writing these commands are: set setnx setex append
 #       incr decr rpush lpush rpushx lpushx linsert lset rpoplpush sadd
 #       sinter sinterstore sunion sunionstore sdiff sdiffstore zadd zincrby
 #       zunionstore zinterstore hset hsetnx hmset hincrby incrby decrby
@@ -378,16 +520,17 @@ maxmemory <%= @redis_max_memory %>
 appendonly no
 
 # The name of the append only file (default: "appendonly.aof")
-# appendfilename appendonly.aof
+
+appendfilename "appendonly.aof"
 
 # The fsync() call tells the Operating System to actually write data on disk
-# instead to wait for more data in the output buffer. Some OS will really flush 
+# instead of waiting for more data in the output buffer. Some OS will really flush
 # data on disk, some other OS will just try to do it ASAP.
 #
 # Redis supports three different modes:
 #
 # no: don't fsync, just let the OS flush the data when it wants. Faster.
-# always: fsync after every write to the append only log . Slow, Safest.
+# always: fsync after every write to the append only log. Slow, Safest.
 # everysec: fsync only one time every second. Compromise.
 #
 # The default is "everysec", as that's usually the right compromise between
@@ -422,15 +565,16 @@ appendfsync everysec
 # the same as "appendfsync none". In practical terms, this means that it is
 # possible to lose up to 30 seconds of log in the worst scenario (with the
 # default Linux settings).
-# 
+#
 # If you have latency problems turn this to "yes". Otherwise leave it as
 # "no" that is the safest pick from the point of view of durability.
+
 no-appendfsync-on-rewrite no
 
 # Automatic rewrite of the append only file.
 # Redis is able to automatically rewrite the log file implicitly calling
 # BGREWRITEAOF when the AOF log size grows by the specified percentage.
-# 
+#
 # This is how it works: Redis remembers the size of the AOF file after the
 # latest rewrite (if no rewrite has happened since the restart, the size of
 # the AOF at startup is used).
@@ -447,6 +591,32 @@ no-appendfsync-on-rewrite no
 auto-aof-rewrite-percentage 100
 auto-aof-rewrite-min-size 64mb
 
+<%- if (version_c <=> [2,8,15]) >= 0 -%>
+# An AOF file may be found to be truncated at the end during the Redis
+# startup process, when the AOF data gets loaded back into memory.
+# This may happen when the system where Redis is running
+# crashes, especially when an ext4 filesystem is mounted without the
+# data=ordered option (however this can't happen when Redis itself
+# crashes or aborts but the operating system still works correctly).
+#
+# Redis can either exit with an error when this happens, or load as much
+# data as possible (the default now) and start if the AOF file is found
+# to be truncated at the end. The following option controls this behavior.
+#
+# If aof-load-truncated is set to yes, a truncated AOF file is loaded and
+# the Redis server starts emitting a log to inform the user of the event.
+# Otherwise if the option is set to no, the server aborts with an error
+# and refuses to start. When the option is set to no, the user requires
+# to fix the AOF file using the "redis-check-aof" utility before to restart
+# the server.
+#
+# Note that if the AOF file will be found to be corrupted in the middle
+# the server will still exit with an error. This option only applies when
+# Redis will try to read more data from the AOF file but not enough bytes
+# will be found.
+aof-load-truncated yes
+<%- end -%>
+
 ################################ LUA SCRIPTING  ###############################
 
 # Max execution time of a Lua script in milliseconds.
@@ -455,11 +625,11 @@ auto-aof-rewrite-min-size 64mb
 # still in execution after the maximum allowed time and will start to
 # reply to queries with an error.
 #
-# When a long running script exceed the maximum execution time only the
+# When a long running script exceeds the maximum execution time only the
 # SCRIPT KILL and SHUTDOWN NOSAVE commands are available. The first can be
 # used to stop a script that did not yet called write commands. The second
-# is the only way to shut down the server in the case a write commands was
-# already issue by the script but the user don't want to wait for the natural
+# is the only way to shut down the server in the case a write command was
+# already issued by the script but the user doesn't want to wait for the natural
 # termination of the script.
 #
 # Set it to 0 or a negative value for unlimited execution without warnings.
@@ -473,7 +643,7 @@ lua-time-limit 5000
 # but just the time needed to actually execute the command (this is the only
 # stage of command execution where the thread is blocked and can not serve
 # other requests in the meantime).
-# 
+#
 # You can configure the slow log with two parameters: one tells Redis
 # what is the execution time, in microseconds, to exceed in order for the
 # command to get logged, and the other parameter is the length of the
@@ -488,6 +658,77 @@ slowlog-log-slower-than <%= @redis_slowlog_log_slower_than %>
 # There is no limit to this length. Just be aware that it will consume memory.
 # You can reclaim memory used by the slow log with SLOWLOG RESET.
 slowlog-max-len <%= @redis_slowlog_max_len %>
+
+################################ LATENCY MONITOR ##############################
+
+<%- if (version_c <=> [2,8,13]) >= 0 -%>
+# The Redis latency monitoring subsystem samples different operations
+# at runtime in order to collect data related to possible sources of
+# latency of a Redis instance.
+#
+# Via the LATENCY command this information is available to the user that can
+# print graphs and obtain reports.
+#
+# The system only logs operations that were performed in a time equal or
+# greater than the amount of milliseconds specified via the
+# latency-monitor-threshold configuration directive. When its value is set
+# to zero, the latency monitor is turned off.
+#
+# By default latency monitoring is disabled since it is mostly not needed
+# if you don't have latency issues, and collecting data has a performance
+# impact, that while very small, can be measured under big load. Latency
+# monitoring can easily be enalbed at runtime using the command
+# "CONFIG SET latency-monitor-threshold <milliseconds>" if needed.
+latency-monitor-threshold 0
+<%- end -%>
+
+############################# Event notification ##############################
+
+<%- if (version_c <=> [2,8,0]) >= 0 -%>
+# Redis can notify Pub/Sub clients about events happening in the key space.
+# This feature is documented at http://redis.io/topics/notifications
+#
+# For instance if keyspace events notification is enabled, and a client
+# performs a DEL operation on key "foo" stored in the Database 0, two
+# messages will be published via Pub/Sub:
+#
+# PUBLISH __keyspace@0__:foo del
+# PUBLISH __keyevent@0__:del foo
+#
+# It is possible to select the events that Redis will notify among a set
+# of classes. Every class is identified by a single character:
+#
+#  K     Keyspace events, published with __keyspace@<db>__ prefix.
+#  E     Keyevent events, published with __keyevent@<db>__ prefix.
+#  g     Generic commands (non-type specific) like DEL, EXPIRE, RENAME, ...
+#  $     String commands
+#  l     List commands
+#  s     Set commands
+#  h     Hash commands
+#  z     Sorted set commands
+#  x     Expired events (events generated every time a key expires)
+#  e     Evicted events (events generated when a key is evicted for maxmemory)
+#  A     Alias for g$lshzxe, so that the "AKE" string means all the events.
+#
+#  The "notify-keyspace-events" takes as argument a string that is composed
+#  of zero or multiple characters. The empty string means that notifications
+#  are disabled.
+#
+#  Example: to enable list and generic events, from the point of view of the
+#           event name, use:
+#
+#  notify-keyspace-events Elg
+#
+#  Example 2: to get the stream of the expired keys subscribing to channel
+#             name __keyevent@0__:expired use:
+#
+#  notify-keyspace-events Ex
+#
+#  By default all notifications are disabled because most users don't need
+#  this feature and the feature has some overhead. Note that if you don't
+#  specify at least one of K or E, no events will be delivered.
+notify-keyspace-events ""
+<%- end -%>
 
 ############################### ADVANCED CONFIG ###############################
 
@@ -504,7 +745,7 @@ list-max-ziplist-entries 512
 list-max-ziplist-value 64
 
 # Sets have a special encoding in just one case: when a set is composed
-# of just strings that happens to be integers in radix 10 in the range
+# of just strings that happen to be integers in radix 10 in the range
 # of 64 bit signed integers.
 # The following configuration setting sets the limit in the size of the
 # set in order to use this special memory saving encoding.
@@ -516,20 +757,36 @@ set-max-intset-entries 512
 zset-max-ziplist-entries 128
 zset-max-ziplist-value 64
 
+<%- if (version_c <=> [2,8,10]) >= 0 -%>
+# HyperLogLog sparse representation bytes limit. The limit includes the
+# 16 bytes header. When an HyperLogLog using the sparse representation crosses
+# this limit, it is converted into the dense representation.
+#
+# A value greater than 16000 is totally useless, since at that point the
+# dense representation is more memory efficient.
+#
+# The suggested value is ~ 3000 in order to have the benefits of
+# the space efficient encoding without slowing down too much PFADD,
+# which is O(N) with the sparse encoding. The value can be raised to
+# ~ 10000 when CPU is not a concern, but space is, and the data set is
+# composed of many HyperLogLogs with cardinality in the 0 - 15000 range.
+hll-sparse-max-bytes 3000
+<%- end -%>
+
 # Active rehashing uses 1 millisecond every 100 milliseconds of CPU time in
 # order to help rehashing the main Redis hash table (the one mapping top-level
 # keys to values). The hash table implementation Redis uses (see dict.c)
-# performs a lazy rehashing: the more operation you run into an hash table
+# performs a lazy rehashing: the more operation you run into a hash table
 # that is rehashing, the more rehashing "steps" are performed, so if the
 # server is idle the rehashing is never complete and some more memory is used
 # by the hash table.
-# 
+#
 # The default is to use this millisecond 10 times every second in order to
-# active rehashing the main dictionaries, freeing memory when possible.
+# actively rehash the main dictionaries, freeing memory when possible.
 #
 # If unsure:
 # use "activerehashing no" if you have hard latency requirements and it is
-# not a good thing in your environment that Redis can reply form time to time
+# not a good thing in your environment that Redis can reply from time to time
 # to queries with 2 milliseconds delay.
 #
 # use "activerehashing yes" if you don't have such hard requirements but
@@ -543,9 +800,9 @@ activerehashing yes
 #
 # The limit can be set differently for the three different classes of clients:
 #
-# normal -> normal clients
-# slave  -> slave clients and MONITOR clients
-# pubsub -> clients subcribed to at least one pubsub channel or pattern
+# normal -> normal clients including MONITOR clients
+# slave  -> slave clients
+# pubsub -> clients subscribed to at least one pubsub channel or pattern
 #
 # The syntax of every client-output-buffer-limit directive is the following:
 #
@@ -574,11 +831,11 @@ client-output-buffer-limit slave 256mb 64mb 60
 client-output-buffer-limit pubsub 32mb 8mb 60
 
 # Redis calls an internal function to perform many background tasks, like
-# closing connections of clients in timeot, purging expired keys that are
+# closing connections of clients in timeout, purging expired keys that are
 # never requested, and so forth.
 #
-# Not all tasks are perforemd with the same frequency, but Redis checks for
-# tasks to perform accordingly to the specified "hz" value.
+# Not all tasks are performed with the same frequency, but Redis checks for
+# tasks to perform according to the specified "hz" value.
 #
 # By default "hz" is set to 10. Raising the value will use more CPU when
 # Redis is idle, but at the same time will make Redis more responsive when
@@ -595,13 +852,3 @@ hz 10
 # in order to commit the file to the disk more incrementally and avoid
 # big latency spikes.
 aof-rewrite-incremental-fsync yes
-
-################################## INCLUDES ###################################
-
-# Include one or more other config files here.  This is useful if you
-# have a standard template that goes to all Redis server but also need
-# to customize a few per-server settings.  Include files can include
-# other files, so use this wisely.
-#
-# include /path/to/local.conf
-# include /path/to/other.conf

--- a/templates/redis_port.conf.erb
+++ b/templates/redis_port.conf.erb
@@ -175,8 +175,8 @@ requirepass <%= @redis_password %>
 # an error 'max number of clients reached'.
 #
 # maxclients 128
-<% if @real_redis_max_clients %>
-maxclients <%= @real_redis_max_clients %>
+<% if @redis_max_clients %>
+maxclients <%= @redis_max_clients %>
 <% end %>
 
 # Don't use more memory than the specified amount of bytes.
@@ -354,13 +354,8 @@ slowlog-max-len <%= @redis_slowlog_max_len %>
 # have at max a given numer of elements, and the biggest element does not
 # exceed a given threshold. You can configure this limits with the following
 # configuration directives.
-<% if @version =~ /^2\.4\.\d+$/ %>
-hash-max-zipmap-entries 512
-hash-max-zipmap-value 64
-<% elsif @version =~ /^2\.[68]\.\d+$/ %>
 hash-max-ziplist-entries 512
 hash-max-ziplist-value 64
-<% end %>
 
 # Similarly to hashes, small lists are also encoded in a special way in order
 # to save a lot of space. The special representation is only used when


### PR DESCRIPTION
This branch contains a series of commits which I hope may be of use to you somehow. Note that some of these changes may be considered backwards-incompatible.
- 2.4.x support is removed. This is because attempting to install those versions resulted in failure, because http://download.redis.io/releases/ no longer contains prior to 2.6.14. The 'old' stream still maintained by Redis as detailed on http://redis.io/download is 2.6.x. This is the backwards-incompatibility alluded to; although the effect for new installs should be the same as it didn't work without the source anyway, it may be that some people are managing existing installations.
- 2.6.14 is currently the earlier source contained on http://download.redis.io/releases/ . Beginning with this version, the `redis_port.conf.erb` is rebuilt, minor-series at a time, with configuration options checked for compatibility in every subsequent release. Sections of configs are wrapped in version tests, in an attempt to provide up-to-date configs with latest comments, yet still compatible with previous versions going back at least to 2.6.14. It is worth noting that parameter tests are not validated at a Puppet module level; rather, parameters which are not understood are simply ignored.
- The removal of 2.4.x support also removes the code which applies strict tests to the version numbers. With this greater relaxation, it is now possible to install 3.0.0-rc1.
- A new group of 8 parameters is exposed, for Append Only File support. 1 parameter is from 2.8.15 only.
- A new group of 6 parameters is exposed, for Cluster support. All parameters are from 3.0.0-rc1 only. It should be noted that Redis Cluster is designated as not yet suitable for production. However, this assists in installing and testing upcoming Cluster support in 3.x.

Peace,
tiredpixel
