### PR TITLE
Adding required LSB comments

### DIFF
--- a/templates/redis.init.erb
+++ b/templates/redis.init.erb
@@ -17,10 +17,10 @@ CONF="/etc/redis/${REDIS_PORT}.conf"
 # Provides: redis_<%= @redis_port %>
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
-# Required-Start: 
-# Required-Stop: 
-# Should-Start: 
-# Should-Stop: 
+# Required-Start: $syslog $remote_fs
+# Required-Stop: $syslog $remote_fs
+# Should-Start: $local_fs
+# Should-Stop: $local_fs
 # Short-Description: start and stop redis_<%= @redis_port %>
 # Description: Redis daemon
 ### END INIT INFO

--- a/templates/redis.init.erb
+++ b/templates/redis.init.erb
@@ -15,6 +15,8 @@ CONF="/etc/redis/${REDIS_PORT}.conf"
 # description: redis_<%= @redis_port %> is the redis daemon.
 ### BEGIN INIT INFO
 # Provides: redis_<%= @redis_port %>
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
 # Required-Start: 
 # Required-Stop: 
 # Should-Start: 


### PR DESCRIPTION
### Changes

These changes add comments that, when missing, reliably returns warnings on my Debian 7 hosts. `insserv: Script redis_6379 is broken: incomplete LSB comment.`
- Fixes error: `insserv: missing 'Default-Start:'  entry: please add even if empty.`
- Fixes error: `insserv: missing 'Default-Stop:'   entry: please add even if empty.`
- Fixes issue #45
### Testing

After applying the changes, all `service redis` commands behave as usual and no errors are shown. The daemon shuts down on system halt as expected and starts up at system boot (if instructed to do so) as expected.
