### PR TITLE
Update redis.init.erb

### DIFF
--- a/templates/redis.init.erb
+++ b/templates/redis.init.erb
@@ -19,6 +19,8 @@ CONF="/etc/redis/${REDIS_PORT}.conf"
 # Required-Stop: 
 # Should-Start: 
 # Should-Stop: 
+# Default-Start:
+# Default-Stop: 
 # Short-Description: start and stop redis_<%= @redis_port %>
 # Description: Redis daemon
 ### END INIT INFO


### PR DESCRIPTION
Debian runlevel were broken, some LSB comments are mandatory :
# Default-Start:
# Default-Stop:
