### PR TITLE
Added parameter redis_max_memory_policy

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,16 @@
 #   Max memory usage configuration.
 #   Default: 4gb
 #
+# [*redis_max_memory_policy*]
+#   Max memory policy configuration:
+#     volatile-lru
+#     allkeys-lru
+#     volatile-random
+#     allkeys-random
+#     volatile-ttl
+#     noeviction
+#   Default: false
+#
 # [*redis_max_clients*]
 #   Set the redis config value maxclients. If no value provided, it is
 #   not included in the configuration for 2.6+ and set to 0 (unlimited)
@@ -91,6 +101,7 @@ class redis (
   $redis_port = $redis::params::redis_port,
   $redis_bind_address = $redis::params::redis_bind_address,
   $redis_max_memory = $redis::params::redis_max_memory,
+  $redis_max_memory_policy = $redis::params::redis_max_memory_policy,
   $redis_max_clients = $redis::params::redis_max_clients,
   $redis_timeout = $redis::params::redis_timeout,
   $redis_loglevel = $redis::params::redis_loglevel,
@@ -112,6 +123,7 @@ class redis (
     redis_port                    => $redis_port,
     redis_bind_address            => $redis_bind_address,
     redis_max_memory              => $redis_max_memory,
+    redis_max_memory_policy       => $redis_max_memory_policy,
     redis_max_clients             => $redis_max_clients,
     redis_timeout                 => $redis_timeout,
     redis_loglevel                => $redis_loglevel,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -16,6 +16,16 @@
 #   Max memory usage configuration.
 #   Default: 4gb
 #
+# [*redis_max_memory_policy*]
+#   Max memory policy configuration:
+#     volatile-lru
+#     allkeys-lru
+#     volatile-random
+#     allkeys-random
+#     volatile-ttl
+#     noeviction
+#   Default: false
+#
 # [*redis_max_clients*]
 #   Set the redis config value maxclients. If no value provided, it is
 #   not included in the configuration for 2.6+ and set to 0 (unlimited)
@@ -71,6 +81,7 @@ define redis::instance (
   $redis_port = $redis::params::redis_port,
   $redis_bind_address = $redis::params::redis_bind_address,
   $redis_max_memory = $redis::params::redis_max_memory,
+  $redis_max_memory_policy = $redis::params::redis_max_memory_policy,
   $redis_max_clients = $redis::params::redis_max_clients,
   $redis_timeout = $redis::params::redis_timeout,
   $redis_loglevel = $redis::params::redis_loglevel,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class redis::params {
   $redis_src_dir = '/opt/redis-src'
   $redis_bin_dir = '/opt/redis'
   $redis_max_memory = '4gb'
+  $redis_max_memory_policy = false
   $redis_max_clients = false
   $redis_timeout = 300         # 0 = disabled
   $redis_loglevel = 'notice'

--- a/templates/redis_port.conf.erb
+++ b/templates/redis_port.conf.erb
@@ -221,6 +221,9 @@ maxmemory <%= @redis_max_memory %>
 # The default is:
 #
 # maxmemory-policy volatile-lru
+<% if @redis_max_memory_policy %>
+maxmemory-policy <%= @redis_max_memory_policy %>
+<% end -%>
 
 # LRU and minimal TTL algorithms are not precise algorithms but approximated
 # algorithms (in order to save memory), so you can select as well the sample


### PR DESCRIPTION
Added the maxmemory-policy on redis, the values
can be:
- volatile-lru
- allkeys-lru
- volatile-random
- allkeys-random
- volatile-ttl
- noeviction
